### PR TITLE
Browserify

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -8,9 +8,13 @@ const Browserify  = require('browserify'),
 
 
 
-const Writer = module.exports = function (files, opts) {
-    const browserify = new Browserify(files, opts);
+const Writer = module.exports = function (files = [], options = {}, bundle = false) {
+    const browserify = new Browserify(files, options);
     const dictionary = {};
+
+    if (bundle) {
+        return browserify;
+    }
 
     const hasher = new stream.Transform({
         objectMode: true,

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -1,41 +1,30 @@
 "use strict";
 
-const   stream      = require('readable-stream'),
-        mdeps       = require('module-deps'),
-        UglifyJS    = require('uglify-js'),
-        shasum      = require('shasum'),
-        assert      = require('assert'),
-        pump        = require('pump');
+const Browserify  = require('browserify'),
+      JSONStream  = require('JSONStream'),
+      UglifyJS    = require('uglify-js'),
+      stream      = require('readable-stream'),
+      shasum      = require('shasum');
 
 
 
-const Writer = module.exports = function (file, minify) {
+const Writer = module.exports = function (files, opts) {
+    const browserify = new Browserify(files, opts);
+    const dictionary = {};
 
-    if (!(this instanceof Writer)) return new Writer(file, minify);
-
-    assert(file, '"file" must be provided');
-
-    let start = process.hrtime();
-
-    let md = mdeps();
-    let dictionary = {};
-
-
-    let hasher = new stream.Transform({
-        objectMode : true,
-
+    const hasher = new stream.Transform({
+        objectMode: true,
         transform: function (obj, enc, next) {
             dictionary[obj.id] = shasum(obj.source);
             this.push(obj);
             next();
         }
-
     });
+    browserify.pipeline.get('deps').push(hasher);
 
 
-    let labeler = new stream.Transform({
-        objectMode : true,
-
+    const labeler = new stream.Transform({
+        objectMode: true,
         transform: function (obj, enc, next) {
             obj.id = dictionary[obj.id];
             Object.keys(obj.deps).forEach((key) => {
@@ -44,30 +33,17 @@ const Writer = module.exports = function (file, minify) {
             this.push(obj);
             next();
         }
-
     });
+    browserify.pipeline.get('label').splice(0, 1, labeler);
 
 
-    let minifyer = new stream.Transform({
-        objectMode : true,
+    // replace the step in browserifys build pipeline which convert the
+    // internal dependency object structure to a browser bundle with a
+    // simple conversion to JSON. this leave us with a stream of
+    // dependencies we can pipe anywhere
 
-        transform: function (obj, enc, next) {
-            if (minify) {
-                let minified = UglifyJS.minify(obj.source, {
-                    fromString: true
-                });
-                obj.source = minified.code;                
-            }
-            this.push(obj);
-            next();
-        }
+    const packer = JSONStream.stringify();
+    browserify.pipeline.get('pack').splice(0, 1, packer);
 
-    });
-
-    md.end({file: file});
-
-    return pump(md, hasher, labeler, minifyer, (err) => {
-        let end = process.hrtime(start);
-        console.log("time:", end[0] + 'sec', end[1]/1000000 + 'ms');
-    });
+    return browserify;
 };

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const Browserify  = require('browserify'),
-      JSONStream  = require('JSONStream'),
       UglifyJS    = require('uglify-js'),
       stream      = require('readable-stream'),
       shasum      = require('shasum');
@@ -41,12 +40,18 @@ const Writer = module.exports = function (files = [], options = {}, bundle = fal
     browserify.pipeline.get('label').splice(0, 1, labeler);
 
 
-    // replace the step in browserifys build pipeline which convert the
-    // internal dependency object structure to a browser bundle with a
-    // simple conversion to JSON. this leave us with a stream of
-    // dependencies we can pipe anywhere
+    // Replace the step in browserifys build pipeline which convert the
+    // internal dependency object structure to a browser bundle transform
+    // which just pipes objects through. This leave us with a stream of
+    // dependency objects we can pipe anywhere
 
-    const packer = JSONStream.stringify();
+    const packer = new stream.Transform({
+        objectMode: true,
+        transform: function (obj, enc, next) {
+            this.push(obj);
+            next();
+        }
+    });
     browserify.pipeline.get('pack').splice(0, 1, packer);
 
     return browserify;

--- a/package.json
+++ b/package.json
@@ -22,18 +22,23 @@
     }
   ],
   "engines": {
-    "node" : "6.x"
+    "node" : "7.x"
   },
   "bugs": {
     "url": "https://github.com/asset-pipe/asset-pipe-js-writer/issues"
   },
-  "licenses": ["MIT"],
+  "license": "MIT",
   "dependencies": {
     "readable-stream": "2.2.1",
-    "shasum": "1.0.2",
-    "module-deps": "4.0.8",
+    "browserify": "13.1.1",
     "JSONStream": "1.2.1",
     "uglify-js": "2.7.4",
-    "pump": "1.0.1"
+    "shasum": "1.0.2"
+  },
+  "devDependencies": {
+    "tap": "8.0.0"
+  },
+  "scripts": {
+    "test": "tap test/*.js"
   }
 }

--- a/test/mock/main.js
+++ b/test/mock/main.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const mod = require('./mod.js');
+console.log('hello from main');
+console.log(mod());

--- a/test/mock/mod.js
+++ b/test/mock/mod.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = () => {
+    return 'hello from mod';
+};

--- a/test/writer.js
+++ b/test/writer.js
@@ -1,0 +1,13 @@
+"use strict";
+
+const tap = require('tap');
+const Writer = require('../');
+
+tap.test('foo() - bar', function (t) {
+    var writer = new Writer('./test/mock/main.js');
+
+    writer.bundle().pipe(process.stdout);
+
+    t.equal(true, true);
+    t.end();
+});


### PR DESCRIPTION
Now intercepting the Browserify pipeline instead of creating our own. This give us the benefit of full Browserify support which again should give support for all Browserify compatible modules, transforms and plugins.