### PR TITLE
fix: prevent modules from producing same id hash

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 coverage
 readme.js
+test/mock/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tmp/**/*
 *.log
 coverage
 .vscode
+!test/mock/identical-implementation/node_modules

--- a/lib/browserify-plugins/id-hasher/id-hash-transform.js
+++ b/lib/browserify-plugins/id-hasher/id-hash-transform.js
@@ -2,6 +2,7 @@
 
 const common = require('asset-pipe-common');
 const { Transform } = require('readable-stream');
+const { relative } = require('path');
 
 module.exports = function idHashTransform(idToHashMap) {
     return new Transform({
@@ -10,7 +11,9 @@ module.exports = function idHashTransform(idToHashMap) {
             // include id and source in hash to avoid situation where
             // multiple modules have the same source code but different
             // depedendencies somewhere down the line.
-            idToHashMap[obj.id] = common.hasher(obj.id + obj.source);
+            idToHashMap[obj.id] = common.hasher(
+                relative(process.cwd(), obj.id) + obj.source
+            );
             this.push(obj);
             next();
         },

--- a/lib/browserify-plugins/id-hasher/id-hash-transform.js
+++ b/lib/browserify-plugins/id-hasher/id-hash-transform.js
@@ -7,7 +7,10 @@ module.exports = function idHashTransform(idToHashMap) {
     return new Transform({
         objectMode: true,
         transform(obj, enc, next) {
-            idToHashMap[obj.id] = common.hasher(obj.source);
+            // include id and source in hash to avoid situation where
+            // multiple modules have the same source code but different
+            // depedendencies somewhere down the line.
+            idToHashMap[obj.id] = common.hasher(obj.id + obj.source);
             this.push(obj);
             next();
         },

--- a/test/__snapshots__/writer.test.js.snap
+++ b/test/__snapshots__/writer.test.js.snap
@@ -99,14 +99,14 @@ console.log('main says hello');
 exports[`feed is not deduped 1`] = `
 "[
   {
-    id: \\"da34d0ca36dc47074b9f140adea29001e5dd86f6457e27f91134f1f7de8eb094\\",
+    id: \\"0e0c593f5f89dd62af488699574c678b4726ad1e3de2e0a81141f3dfc02b6037\\",
     source:
       \\"'use strict';\\\\n\\\\nvar fizzbuzz = require('asset-pipe-test-es5b');\\\\nvar util = require('./util.js');\\\\n\\\\nconsole.log(util.helloWorld());\\\\nconsole.log(util.helloNumber());\\\\nfizzbuzz({s:4, e:20}, function (mgs) {\\\\n    console.log(mgs);\\\\n});\\\\n\\",
     deps: {
       \\"./util.js\\":
-        \\"69cb155d3e533cc9c8c419cc89f27ca6c0a34fdefa889754a06e8ec68541ac04\\",
+        \\"d286af219ef4acea1b486c460bdc65443fba40bd913457ce3e256ccc221f2d07\\",
       \\"asset-pipe-test-es5b\\":
-        \\"427feef8cc6bd1678b92f1049b2df0d23a024b968fda0796fada3e67e6f9f35b\\"
+        \\"ecd571b921d0e82abe77bd7cbe5c97c9186504c86f840fb8bdc0a372310231c3\\"
     },
     file: \\"asset-pipe-js-writer/node_modules/asset-pipe-test-es5a/lib/main.js\\",
     index: 1,
@@ -116,12 +116,12 @@ exports[`feed is not deduped 1`] = `
     }
   },
   {
-    id: \\"69cb155d3e533cc9c8c419cc89f27ca6c0a34fdefa889754a06e8ec68541ac04\\",
+    id: \\"d286af219ef4acea1b486c460bdc65443fba40bd913457ce3e256ccc221f2d07\\",
     source:
       \\"'use strict';\\\\n\\\\nvar isPrime = require('asset-pipe-test-es5c');\\\\n\\\\nfunction hello() {\\\\n    return 'Hello world!';\\\\n}\\\\n\\\\nfunction numb(num) {\\\\n    if (isPrime(num)) {\\\\n        return 'Not a prime number';\\\\n    }\\\\n    return 'A prime number';\\\\n}\\\\n\\\\nmodule.exports.helloWorld = hello;\\\\nmodule.exports.helloNumber = numb;\\\\n\\",
     deps: {
       \\"asset-pipe-test-es5c\\":
-        \\"67aa820392d57ad7d93c384df468b87452a4ab89ea3e322a70b1dbb4350ce339\\"
+        \\"a8307dbbd8da4b0752187d0f5aaf7184da3b85743e87ec77110ed88e36370047\\"
     },
     file: \\"asset-pipe-js-writer/node_modules/asset-pipe-test-es5a/lib/util.js\\",
     index: 2,
@@ -130,12 +130,12 @@ exports[`feed is not deduped 1`] = `
     }
   },
   {
-    id: \\"427feef8cc6bd1678b92f1049b2df0d23a024b968fda0796fada3e67e6f9f35b\\",
+    id: \\"ecd571b921d0e82abe77bd7cbe5c97c9186504c86f840fb8bdc0a372310231c3\\",
     source:
       \\"'use strict';\\\\n\\\\nvar isPrime = require('asset-pipe-test-es5c');\\\\n\\\\n/**\\\\n * Run through FizzBuzz for n integers\\\\n *\\\\n * @param {Number} config.s The number to start at\\\\n * @param {Number} config.e The number to end at\\\\n * @param {function} callback\\\\n */\\\\n\\\\nfunction fizzbuzz (config, callback) {\\\\n    for (var i = config.s; i <= config.e; i++) {\\\\n        var prime = '';\\\\n        if (config.p && isPrime(i)) {\\\\n            prime = ' Prime';\\\\n        }\\\\n\\\\n        if (!(i % 15)) {\\\\n            callback('FizzBuzz');\\\\n            continue;\\\\n        } else if (!(i % 3)) {\\\\n            callback('Fizz' + prime);\\\\n            continue;\\\\n        } else if (!(i % 5)) {\\\\n            callback('Buzz' + prime);\\\\n            continue;\\\\n        }\\\\n        callback(prime.trim() || i);\\\\n    }\\\\n};\\\\n\\\\nmodule.exports = fizzbuzz;\\\\n\\",
     deps: {
       \\"asset-pipe-test-es5c\\":
-        \\"67aa820392d57ad7d93c384df468b87452a4ab89ea3e322a70b1dbb4350ce339\\"
+        \\"a8307dbbd8da4b0752187d0f5aaf7184da3b85743e87ec77110ed88e36370047\\"
     },
     file: \\"asset-pipe-js-writer/node_modules/asset-pipe-test-es5b/main.js\\",
     index: 3,
@@ -144,7 +144,7 @@ exports[`feed is not deduped 1`] = `
     }
   },
   {
-    id: \\"67aa820392d57ad7d93c384df468b87452a4ab89ea3e322a70b1dbb4350ce339\\",
+    id: \\"a8307dbbd8da4b0752187d0f5aaf7184da3b85743e87ec77110ed88e36370047\\",
     source:
       \\"'use strict';\\\\n\\\\n function prime (num) {\\\\n    if (num < 4) {\\\\n        return true;\\\\n    }\\\\n    var max = Math.ceil(Math.sqrt(num));\\\\n    for (var i = 2; i <= max; i++) {\\\\n        if (num % i === 0) {\\\\n            return false;\\\\n        }\\\\n    }\\\\n    return true;\\\\n};\\\\n\\\\nmodule.exports = prime;\\\\n\\",
     deps: {},
@@ -153,11 +153,11 @@ exports[`feed is not deduped 1`] = `
     indexDeps: {}
   },
   {
-    id: \\"29307fdb685c1420aa7b3b357eacdaed2a4c953b71bbd776dfb398f451ad7f05\\",
+    id: \\"17cec02a29ba2621285a0c6928e7b6f91f9e10cbaa45be1eddbf4faed55c8b3d\\",
     source: \\"'use strict';\\\\n\\\\nrequire('./main');\\\\n\\",
     deps: {
       \\"./main\\":
-        \\"eae04b1ae2a4f9822b36015cb458186dcec69821e785f796f243d2ad994dd768\\"
+        \\"6bc16f4686fe6cf0bb03134e009a29a452568f28f6b0e1174f8d75d47366a6ec\\"
     },
     file: \\"asset-pipe-js-writer/test/mock/common.js\\",
     index: 5,
@@ -166,12 +166,12 @@ exports[`feed is not deduped 1`] = `
     }
   },
   {
-    id: \\"eae04b1ae2a4f9822b36015cb458186dcec69821e785f796f243d2ad994dd768\\",
+    id: \\"6bc16f4686fe6cf0bb03134e009a29a452568f28f6b0e1174f8d75d47366a6ec\\",
     source:
       \\"'use strict';\\\\n\\\\nrequire('asset-pipe-test-es5a');\\\\nconsole.log('main says hello');\\\\n\\",
     deps: {
       \\"asset-pipe-test-es5a\\":
-        \\"da34d0ca36dc47074b9f140adea29001e5dd86f6457e27f91134f1f7de8eb094\\"
+        \\"0e0c593f5f89dd62af488699574c678b4726ad1e3de2e0a81141f3dfc02b6037\\"
     },
     file: \\"asset-pipe-js-writer/test/mock/main.js\\",
     index: 6,
@@ -183,14 +183,14 @@ exports[`feed is not deduped 1`] = `
     entry: true,
     expose: false,
     file: \\"asset-pipe-js-writer/test/mock/no-dedupe.js\\",
-    id: \\"589440eec97668c3f811548b2be4d9883b568ce4d9ab5dc36da523bbd13a9c67\\",
+    id: \\"c98cd71bd49ced468ea7011b8733d1a4f940f28f9336797fe7c24687d2d82dc6\\",
     order: 0,
     source: \\"'use strict';\\\\n\\\\nrequire('./common');\\\\nrequire('./main');\\\\n\\",
     deps: {
       \\"./common\\":
-        \\"29307fdb685c1420aa7b3b357eacdaed2a4c953b71bbd776dfb398f451ad7f05\\",
+        \\"17cec02a29ba2621285a0c6928e7b6f91f9e10cbaa45be1eddbf4faed55c8b3d\\",
       \\"./main\\":
-        \\"eae04b1ae2a4f9822b36015cb458186dcec69821e785f796f243d2ad994dd768\\"
+        \\"6bc16f4686fe6cf0bb03134e009a29a452568f28f6b0e1174f8d75d47366a6ec\\"
     },
     index: 7,
     indexDeps: {
@@ -207,14 +207,14 @@ exports[`module throws if \`files\` argument is not an array 1`] = `"Expected 'f
 exports[`options object passes options on to browserify 1`] = `
 "[
   {
-    id: \\"da34d0ca36dc47074b9f140adea29001e5dd86f6457e27f91134f1f7de8eb094\\",
+    id: \\"0e0c593f5f89dd62af488699574c678b4726ad1e3de2e0a81141f3dfc02b6037\\",
     source:
       \\"'use strict';\\\\n\\\\nvar fizzbuzz = require('asset-pipe-test-es5b');\\\\nvar util = require('./util.js');\\\\n\\\\nconsole.log(util.helloWorld());\\\\nconsole.log(util.helloNumber());\\\\nfizzbuzz({s:4, e:20}, function (mgs) {\\\\n    console.log(mgs);\\\\n});\\\\n\\",
     deps: {
       \\"./util.js\\":
-        \\"69cb155d3e533cc9c8c419cc89f27ca6c0a34fdefa889754a06e8ec68541ac04\\",
+        \\"d286af219ef4acea1b486c460bdc65443fba40bd913457ce3e256ccc221f2d07\\",
       \\"asset-pipe-test-es5b\\":
-        \\"427feef8cc6bd1678b92f1049b2df0d23a024b968fda0796fada3e67e6f9f35b\\"
+        \\"ecd571b921d0e82abe77bd7cbe5c97c9186504c86f840fb8bdc0a372310231c3\\"
     },
     file: \\"asset-pipe-js-writer/node_modules/asset-pipe-test-es5a/lib/main.js\\",
     index: 1,
@@ -226,12 +226,12 @@ exports[`options object passes options on to browserify 1`] = `
     sourceFile: \\"node_modules/asset-pipe-test-es5a/lib/main.js\\"
   },
   {
-    id: \\"69cb155d3e533cc9c8c419cc89f27ca6c0a34fdefa889754a06e8ec68541ac04\\",
+    id: \\"d286af219ef4acea1b486c460bdc65443fba40bd913457ce3e256ccc221f2d07\\",
     source:
       \\"'use strict';\\\\n\\\\nvar isPrime = require('asset-pipe-test-es5c');\\\\n\\\\nfunction hello() {\\\\n    return 'Hello world!';\\\\n}\\\\n\\\\nfunction numb(num) {\\\\n    if (isPrime(num)) {\\\\n        return 'Not a prime number';\\\\n    }\\\\n    return 'A prime number';\\\\n}\\\\n\\\\nmodule.exports.helloWorld = hello;\\\\nmodule.exports.helloNumber = numb;\\\\n\\",
     deps: {
       \\"asset-pipe-test-es5c\\":
-        \\"67aa820392d57ad7d93c384df468b87452a4ab89ea3e322a70b1dbb4350ce339\\"
+        \\"a8307dbbd8da4b0752187d0f5aaf7184da3b85743e87ec77110ed88e36370047\\"
     },
     file: \\"asset-pipe-js-writer/node_modules/asset-pipe-test-es5a/lib/util.js\\",
     index: 2,
@@ -242,12 +242,12 @@ exports[`options object passes options on to browserify 1`] = `
     sourceFile: \\"node_modules/asset-pipe-test-es5a/lib/util.js\\"
   },
   {
-    id: \\"427feef8cc6bd1678b92f1049b2df0d23a024b968fda0796fada3e67e6f9f35b\\",
+    id: \\"ecd571b921d0e82abe77bd7cbe5c97c9186504c86f840fb8bdc0a372310231c3\\",
     source:
       \\"'use strict';\\\\n\\\\nvar isPrime = require('asset-pipe-test-es5c');\\\\n\\\\n/**\\\\n * Run through FizzBuzz for n integers\\\\n *\\\\n * @param {Number} config.s The number to start at\\\\n * @param {Number} config.e The number to end at\\\\n * @param {function} callback\\\\n */\\\\n\\\\nfunction fizzbuzz (config, callback) {\\\\n    for (var i = config.s; i <= config.e; i++) {\\\\n        var prime = '';\\\\n        if (config.p && isPrime(i)) {\\\\n            prime = ' Prime';\\\\n        }\\\\n\\\\n        if (!(i % 15)) {\\\\n            callback('FizzBuzz');\\\\n            continue;\\\\n        } else if (!(i % 3)) {\\\\n            callback('Fizz' + prime);\\\\n            continue;\\\\n        } else if (!(i % 5)) {\\\\n            callback('Buzz' + prime);\\\\n            continue;\\\\n        }\\\\n        callback(prime.trim() || i);\\\\n    }\\\\n};\\\\n\\\\nmodule.exports = fizzbuzz;\\\\n\\",
     deps: {
       \\"asset-pipe-test-es5c\\":
-        \\"67aa820392d57ad7d93c384df468b87452a4ab89ea3e322a70b1dbb4350ce339\\"
+        \\"a8307dbbd8da4b0752187d0f5aaf7184da3b85743e87ec77110ed88e36370047\\"
     },
     file: \\"asset-pipe-js-writer/node_modules/asset-pipe-test-es5b/main.js\\",
     index: 3,
@@ -258,7 +258,7 @@ exports[`options object passes options on to browserify 1`] = `
     sourceFile: \\"node_modules/asset-pipe-test-es5b/main.js\\"
   },
   {
-    id: \\"67aa820392d57ad7d93c384df468b87452a4ab89ea3e322a70b1dbb4350ce339\\",
+    id: \\"a8307dbbd8da4b0752187d0f5aaf7184da3b85743e87ec77110ed88e36370047\\",
     source:
       \\"'use strict';\\\\n\\\\n function prime (num) {\\\\n    if (num < 4) {\\\\n        return true;\\\\n    }\\\\n    var max = Math.ceil(Math.sqrt(num));\\\\n    for (var i = 2; i <= max; i++) {\\\\n        if (num % i === 0) {\\\\n            return false;\\\\n        }\\\\n    }\\\\n    return true;\\\\n};\\\\n\\\\nmodule.exports = prime;\\\\n\\",
     deps: {},
@@ -272,13 +272,13 @@ exports[`options object passes options on to browserify 1`] = `
     entry: true,
     expose: false,
     file: \\"asset-pipe-js-writer/test/mock/main.js\\",
-    id: \\"eae04b1ae2a4f9822b36015cb458186dcec69821e785f796f243d2ad994dd768\\",
+    id: \\"6bc16f4686fe6cf0bb03134e009a29a452568f28f6b0e1174f8d75d47366a6ec\\",
     order: 0,
     source:
       \\"'use strict';\\\\n\\\\nrequire('asset-pipe-test-es5a');\\\\nconsole.log('main says hello');\\\\n\\",
     deps: {
       \\"asset-pipe-test-es5a\\":
-        \\"da34d0ca36dc47074b9f140adea29001e5dd86f6457e27f91134f1f7de8eb094\\"
+        \\"0e0c593f5f89dd62af488699574c678b4726ad1e3de2e0a81141f3dfc02b6037\\"
     },
     index: 5,
     indexDeps: {
@@ -294,14 +294,14 @@ exports[`options object passes options on to browserify 1`] = `
 exports[`writer produces a feed of dependencies with ids hashed 1`] = `
 "[
   {
-    id: \\"da34d0ca36dc47074b9f140adea29001e5dd86f6457e27f91134f1f7de8eb094\\",
+    id: \\"0e0c593f5f89dd62af488699574c678b4726ad1e3de2e0a81141f3dfc02b6037\\",
     source:
       \\"'use strict';\\\\n\\\\nvar fizzbuzz = require('asset-pipe-test-es5b');\\\\nvar util = require('./util.js');\\\\n\\\\nconsole.log(util.helloWorld());\\\\nconsole.log(util.helloNumber());\\\\nfizzbuzz({s:4, e:20}, function (mgs) {\\\\n    console.log(mgs);\\\\n});\\\\n\\",
     deps: {
       \\"./util.js\\":
-        \\"69cb155d3e533cc9c8c419cc89f27ca6c0a34fdefa889754a06e8ec68541ac04\\",
+        \\"d286af219ef4acea1b486c460bdc65443fba40bd913457ce3e256ccc221f2d07\\",
       \\"asset-pipe-test-es5b\\":
-        \\"427feef8cc6bd1678b92f1049b2df0d23a024b968fda0796fada3e67e6f9f35b\\"
+        \\"ecd571b921d0e82abe77bd7cbe5c97c9186504c86f840fb8bdc0a372310231c3\\"
     },
     file: \\"asset-pipe-js-writer/node_modules/asset-pipe-test-es5a/lib/main.js\\",
     index: 1,
@@ -311,12 +311,12 @@ exports[`writer produces a feed of dependencies with ids hashed 1`] = `
     }
   },
   {
-    id: \\"69cb155d3e533cc9c8c419cc89f27ca6c0a34fdefa889754a06e8ec68541ac04\\",
+    id: \\"d286af219ef4acea1b486c460bdc65443fba40bd913457ce3e256ccc221f2d07\\",
     source:
       \\"'use strict';\\\\n\\\\nvar isPrime = require('asset-pipe-test-es5c');\\\\n\\\\nfunction hello() {\\\\n    return 'Hello world!';\\\\n}\\\\n\\\\nfunction numb(num) {\\\\n    if (isPrime(num)) {\\\\n        return 'Not a prime number';\\\\n    }\\\\n    return 'A prime number';\\\\n}\\\\n\\\\nmodule.exports.helloWorld = hello;\\\\nmodule.exports.helloNumber = numb;\\\\n\\",
     deps: {
       \\"asset-pipe-test-es5c\\":
-        \\"67aa820392d57ad7d93c384df468b87452a4ab89ea3e322a70b1dbb4350ce339\\"
+        \\"a8307dbbd8da4b0752187d0f5aaf7184da3b85743e87ec77110ed88e36370047\\"
     },
     file: \\"asset-pipe-js-writer/node_modules/asset-pipe-test-es5a/lib/util.js\\",
     index: 2,
@@ -325,12 +325,12 @@ exports[`writer produces a feed of dependencies with ids hashed 1`] = `
     }
   },
   {
-    id: \\"427feef8cc6bd1678b92f1049b2df0d23a024b968fda0796fada3e67e6f9f35b\\",
+    id: \\"ecd571b921d0e82abe77bd7cbe5c97c9186504c86f840fb8bdc0a372310231c3\\",
     source:
       \\"'use strict';\\\\n\\\\nvar isPrime = require('asset-pipe-test-es5c');\\\\n\\\\n/**\\\\n * Run through FizzBuzz for n integers\\\\n *\\\\n * @param {Number} config.s The number to start at\\\\n * @param {Number} config.e The number to end at\\\\n * @param {function} callback\\\\n */\\\\n\\\\nfunction fizzbuzz (config, callback) {\\\\n    for (var i = config.s; i <= config.e; i++) {\\\\n        var prime = '';\\\\n        if (config.p && isPrime(i)) {\\\\n            prime = ' Prime';\\\\n        }\\\\n\\\\n        if (!(i % 15)) {\\\\n            callback('FizzBuzz');\\\\n            continue;\\\\n        } else if (!(i % 3)) {\\\\n            callback('Fizz' + prime);\\\\n            continue;\\\\n        } else if (!(i % 5)) {\\\\n            callback('Buzz' + prime);\\\\n            continue;\\\\n        }\\\\n        callback(prime.trim() || i);\\\\n    }\\\\n};\\\\n\\\\nmodule.exports = fizzbuzz;\\\\n\\",
     deps: {
       \\"asset-pipe-test-es5c\\":
-        \\"67aa820392d57ad7d93c384df468b87452a4ab89ea3e322a70b1dbb4350ce339\\"
+        \\"a8307dbbd8da4b0752187d0f5aaf7184da3b85743e87ec77110ed88e36370047\\"
     },
     file: \\"asset-pipe-js-writer/node_modules/asset-pipe-test-es5b/main.js\\",
     index: 3,
@@ -339,7 +339,7 @@ exports[`writer produces a feed of dependencies with ids hashed 1`] = `
     }
   },
   {
-    id: \\"67aa820392d57ad7d93c384df468b87452a4ab89ea3e322a70b1dbb4350ce339\\",
+    id: \\"a8307dbbd8da4b0752187d0f5aaf7184da3b85743e87ec77110ed88e36370047\\",
     source:
       \\"'use strict';\\\\n\\\\n function prime (num) {\\\\n    if (num < 4) {\\\\n        return true;\\\\n    }\\\\n    var max = Math.ceil(Math.sqrt(num));\\\\n    for (var i = 2; i <= max; i++) {\\\\n        if (num % i === 0) {\\\\n            return false;\\\\n        }\\\\n    }\\\\n    return true;\\\\n};\\\\n\\\\nmodule.exports = prime;\\\\n\\",
     deps: {},
@@ -351,13 +351,13 @@ exports[`writer produces a feed of dependencies with ids hashed 1`] = `
     entry: true,
     expose: false,
     file: \\"asset-pipe-js-writer/test/mock/main.js\\",
-    id: \\"eae04b1ae2a4f9822b36015cb458186dcec69821e785f796f243d2ad994dd768\\",
+    id: \\"6bc16f4686fe6cf0bb03134e009a29a452568f28f6b0e1174f8d75d47366a6ec\\",
     order: 0,
     source:
       \\"'use strict';\\\\n\\\\nrequire('asset-pipe-test-es5a');\\\\nconsole.log('main says hello');\\\\n\\",
     deps: {
       \\"asset-pipe-test-es5a\\":
-        \\"da34d0ca36dc47074b9f140adea29001e5dd86f6457e27f91134f1f7de8eb094\\"
+        \\"0e0c593f5f89dd62af488699574c678b4726ad1e3de2e0a81141f3dfc02b6037\\"
     },
     index: 5,
     indexDeps: {

--- a/test/__snapshots__/writer.test.js.snap
+++ b/test/__snapshots__/writer.test.js.snap
@@ -99,14 +99,14 @@ console.log('main says hello');
 exports[`feed is not deduped 1`] = `
 "[
   {
-    id: \\"18b899957f7b0dfbb0e7ab22606904ffea55126f338efca91203c4df2f8d76ad\\",
+    id: \\"da34d0ca36dc47074b9f140adea29001e5dd86f6457e27f91134f1f7de8eb094\\",
     source:
       \\"'use strict';\\\\n\\\\nvar fizzbuzz = require('asset-pipe-test-es5b');\\\\nvar util = require('./util.js');\\\\n\\\\nconsole.log(util.helloWorld());\\\\nconsole.log(util.helloNumber());\\\\nfizzbuzz({s:4, e:20}, function (mgs) {\\\\n    console.log(mgs);\\\\n});\\\\n\\",
     deps: {
       \\"./util.js\\":
-        \\"e2d2292212a0dcea8006331903fe562b9ac3eb46148bdfd3836273fd9a7db609\\",
+        \\"69cb155d3e533cc9c8c419cc89f27ca6c0a34fdefa889754a06e8ec68541ac04\\",
       \\"asset-pipe-test-es5b\\":
-        \\"110e7030dde4afcbbc598c046f76700ab7eb851a52709f3086b2d60c31330087\\"
+        \\"427feef8cc6bd1678b92f1049b2df0d23a024b968fda0796fada3e67e6f9f35b\\"
     },
     file: \\"asset-pipe-js-writer/node_modules/asset-pipe-test-es5a/lib/main.js\\",
     index: 1,
@@ -116,12 +116,12 @@ exports[`feed is not deduped 1`] = `
     }
   },
   {
-    id: \\"e2d2292212a0dcea8006331903fe562b9ac3eb46148bdfd3836273fd9a7db609\\",
+    id: \\"69cb155d3e533cc9c8c419cc89f27ca6c0a34fdefa889754a06e8ec68541ac04\\",
     source:
       \\"'use strict';\\\\n\\\\nvar isPrime = require('asset-pipe-test-es5c');\\\\n\\\\nfunction hello() {\\\\n    return 'Hello world!';\\\\n}\\\\n\\\\nfunction numb(num) {\\\\n    if (isPrime(num)) {\\\\n        return 'Not a prime number';\\\\n    }\\\\n    return 'A prime number';\\\\n}\\\\n\\\\nmodule.exports.helloWorld = hello;\\\\nmodule.exports.helloNumber = numb;\\\\n\\",
     deps: {
       \\"asset-pipe-test-es5c\\":
-        \\"155c2235c68a81d7df2f9bfb79149d679bf187c69e815d8c5c4fa3d5def2ad3b\\"
+        \\"67aa820392d57ad7d93c384df468b87452a4ab89ea3e322a70b1dbb4350ce339\\"
     },
     file: \\"asset-pipe-js-writer/node_modules/asset-pipe-test-es5a/lib/util.js\\",
     index: 2,
@@ -130,12 +130,12 @@ exports[`feed is not deduped 1`] = `
     }
   },
   {
-    id: \\"110e7030dde4afcbbc598c046f76700ab7eb851a52709f3086b2d60c31330087\\",
+    id: \\"427feef8cc6bd1678b92f1049b2df0d23a024b968fda0796fada3e67e6f9f35b\\",
     source:
       \\"'use strict';\\\\n\\\\nvar isPrime = require('asset-pipe-test-es5c');\\\\n\\\\n/**\\\\n * Run through FizzBuzz for n integers\\\\n *\\\\n * @param {Number} config.s The number to start at\\\\n * @param {Number} config.e The number to end at\\\\n * @param {function} callback\\\\n */\\\\n\\\\nfunction fizzbuzz (config, callback) {\\\\n    for (var i = config.s; i <= config.e; i++) {\\\\n        var prime = '';\\\\n        if (config.p && isPrime(i)) {\\\\n            prime = ' Prime';\\\\n        }\\\\n\\\\n        if (!(i % 15)) {\\\\n            callback('FizzBuzz');\\\\n            continue;\\\\n        } else if (!(i % 3)) {\\\\n            callback('Fizz' + prime);\\\\n            continue;\\\\n        } else if (!(i % 5)) {\\\\n            callback('Buzz' + prime);\\\\n            continue;\\\\n        }\\\\n        callback(prime.trim() || i);\\\\n    }\\\\n};\\\\n\\\\nmodule.exports = fizzbuzz;\\\\n\\",
     deps: {
       \\"asset-pipe-test-es5c\\":
-        \\"155c2235c68a81d7df2f9bfb79149d679bf187c69e815d8c5c4fa3d5def2ad3b\\"
+        \\"67aa820392d57ad7d93c384df468b87452a4ab89ea3e322a70b1dbb4350ce339\\"
     },
     file: \\"asset-pipe-js-writer/node_modules/asset-pipe-test-es5b/main.js\\",
     index: 3,
@@ -144,7 +144,7 @@ exports[`feed is not deduped 1`] = `
     }
   },
   {
-    id: \\"155c2235c68a81d7df2f9bfb79149d679bf187c69e815d8c5c4fa3d5def2ad3b\\",
+    id: \\"67aa820392d57ad7d93c384df468b87452a4ab89ea3e322a70b1dbb4350ce339\\",
     source:
       \\"'use strict';\\\\n\\\\n function prime (num) {\\\\n    if (num < 4) {\\\\n        return true;\\\\n    }\\\\n    var max = Math.ceil(Math.sqrt(num));\\\\n    for (var i = 2; i <= max; i++) {\\\\n        if (num % i === 0) {\\\\n            return false;\\\\n        }\\\\n    }\\\\n    return true;\\\\n};\\\\n\\\\nmodule.exports = prime;\\\\n\\",
     deps: {},
@@ -153,11 +153,11 @@ exports[`feed is not deduped 1`] = `
     indexDeps: {}
   },
   {
-    id: \\"a5c59156f7c7ba1eba4054b26464dc523cfd5611ea4bf528e15f3cf0fc11e84a\\",
+    id: \\"29307fdb685c1420aa7b3b357eacdaed2a4c953b71bbd776dfb398f451ad7f05\\",
     source: \\"'use strict';\\\\n\\\\nrequire('./main');\\\\n\\",
     deps: {
       \\"./main\\":
-        \\"ba83602a6ebf462378a3dd0ad7ad8c8ef9b45d6968362609d44c75b9e48f2847\\"
+        \\"eae04b1ae2a4f9822b36015cb458186dcec69821e785f796f243d2ad994dd768\\"
     },
     file: \\"asset-pipe-js-writer/test/mock/common.js\\",
     index: 5,
@@ -166,12 +166,12 @@ exports[`feed is not deduped 1`] = `
     }
   },
   {
-    id: \\"ba83602a6ebf462378a3dd0ad7ad8c8ef9b45d6968362609d44c75b9e48f2847\\",
+    id: \\"eae04b1ae2a4f9822b36015cb458186dcec69821e785f796f243d2ad994dd768\\",
     source:
       \\"'use strict';\\\\n\\\\nrequire('asset-pipe-test-es5a');\\\\nconsole.log('main says hello');\\\\n\\",
     deps: {
       \\"asset-pipe-test-es5a\\":
-        \\"18b899957f7b0dfbb0e7ab22606904ffea55126f338efca91203c4df2f8d76ad\\"
+        \\"da34d0ca36dc47074b9f140adea29001e5dd86f6457e27f91134f1f7de8eb094\\"
     },
     file: \\"asset-pipe-js-writer/test/mock/main.js\\",
     index: 6,
@@ -183,14 +183,14 @@ exports[`feed is not deduped 1`] = `
     entry: true,
     expose: false,
     file: \\"asset-pipe-js-writer/test/mock/no-dedupe.js\\",
-    id: \\"12505fde83a0c1875bb4a9723a9c113de5d5085a426a34af956406d1f97977e7\\",
+    id: \\"589440eec97668c3f811548b2be4d9883b568ce4d9ab5dc36da523bbd13a9c67\\",
     order: 0,
     source: \\"'use strict';\\\\n\\\\nrequire('./common');\\\\nrequire('./main');\\\\n\\",
     deps: {
       \\"./common\\":
-        \\"a5c59156f7c7ba1eba4054b26464dc523cfd5611ea4bf528e15f3cf0fc11e84a\\",
+        \\"29307fdb685c1420aa7b3b357eacdaed2a4c953b71bbd776dfb398f451ad7f05\\",
       \\"./main\\":
-        \\"ba83602a6ebf462378a3dd0ad7ad8c8ef9b45d6968362609d44c75b9e48f2847\\"
+        \\"eae04b1ae2a4f9822b36015cb458186dcec69821e785f796f243d2ad994dd768\\"
     },
     index: 7,
     indexDeps: {
@@ -207,14 +207,14 @@ exports[`module throws if \`files\` argument is not an array 1`] = `"Expected 'f
 exports[`options object passes options on to browserify 1`] = `
 "[
   {
-    id: \\"18b899957f7b0dfbb0e7ab22606904ffea55126f338efca91203c4df2f8d76ad\\",
+    id: \\"da34d0ca36dc47074b9f140adea29001e5dd86f6457e27f91134f1f7de8eb094\\",
     source:
       \\"'use strict';\\\\n\\\\nvar fizzbuzz = require('asset-pipe-test-es5b');\\\\nvar util = require('./util.js');\\\\n\\\\nconsole.log(util.helloWorld());\\\\nconsole.log(util.helloNumber());\\\\nfizzbuzz({s:4, e:20}, function (mgs) {\\\\n    console.log(mgs);\\\\n});\\\\n\\",
     deps: {
       \\"./util.js\\":
-        \\"e2d2292212a0dcea8006331903fe562b9ac3eb46148bdfd3836273fd9a7db609\\",
+        \\"69cb155d3e533cc9c8c419cc89f27ca6c0a34fdefa889754a06e8ec68541ac04\\",
       \\"asset-pipe-test-es5b\\":
-        \\"110e7030dde4afcbbc598c046f76700ab7eb851a52709f3086b2d60c31330087\\"
+        \\"427feef8cc6bd1678b92f1049b2df0d23a024b968fda0796fada3e67e6f9f35b\\"
     },
     file: \\"asset-pipe-js-writer/node_modules/asset-pipe-test-es5a/lib/main.js\\",
     index: 1,
@@ -226,12 +226,12 @@ exports[`options object passes options on to browserify 1`] = `
     sourceFile: \\"node_modules/asset-pipe-test-es5a/lib/main.js\\"
   },
   {
-    id: \\"e2d2292212a0dcea8006331903fe562b9ac3eb46148bdfd3836273fd9a7db609\\",
+    id: \\"69cb155d3e533cc9c8c419cc89f27ca6c0a34fdefa889754a06e8ec68541ac04\\",
     source:
       \\"'use strict';\\\\n\\\\nvar isPrime = require('asset-pipe-test-es5c');\\\\n\\\\nfunction hello() {\\\\n    return 'Hello world!';\\\\n}\\\\n\\\\nfunction numb(num) {\\\\n    if (isPrime(num)) {\\\\n        return 'Not a prime number';\\\\n    }\\\\n    return 'A prime number';\\\\n}\\\\n\\\\nmodule.exports.helloWorld = hello;\\\\nmodule.exports.helloNumber = numb;\\\\n\\",
     deps: {
       \\"asset-pipe-test-es5c\\":
-        \\"155c2235c68a81d7df2f9bfb79149d679bf187c69e815d8c5c4fa3d5def2ad3b\\"
+        \\"67aa820392d57ad7d93c384df468b87452a4ab89ea3e322a70b1dbb4350ce339\\"
     },
     file: \\"asset-pipe-js-writer/node_modules/asset-pipe-test-es5a/lib/util.js\\",
     index: 2,
@@ -242,12 +242,12 @@ exports[`options object passes options on to browserify 1`] = `
     sourceFile: \\"node_modules/asset-pipe-test-es5a/lib/util.js\\"
   },
   {
-    id: \\"110e7030dde4afcbbc598c046f76700ab7eb851a52709f3086b2d60c31330087\\",
+    id: \\"427feef8cc6bd1678b92f1049b2df0d23a024b968fda0796fada3e67e6f9f35b\\",
     source:
       \\"'use strict';\\\\n\\\\nvar isPrime = require('asset-pipe-test-es5c');\\\\n\\\\n/**\\\\n * Run through FizzBuzz for n integers\\\\n *\\\\n * @param {Number} config.s The number to start at\\\\n * @param {Number} config.e The number to end at\\\\n * @param {function} callback\\\\n */\\\\n\\\\nfunction fizzbuzz (config, callback) {\\\\n    for (var i = config.s; i <= config.e; i++) {\\\\n        var prime = '';\\\\n        if (config.p && isPrime(i)) {\\\\n            prime = ' Prime';\\\\n        }\\\\n\\\\n        if (!(i % 15)) {\\\\n            callback('FizzBuzz');\\\\n            continue;\\\\n        } else if (!(i % 3)) {\\\\n            callback('Fizz' + prime);\\\\n            continue;\\\\n        } else if (!(i % 5)) {\\\\n            callback('Buzz' + prime);\\\\n            continue;\\\\n        }\\\\n        callback(prime.trim() || i);\\\\n    }\\\\n};\\\\n\\\\nmodule.exports = fizzbuzz;\\\\n\\",
     deps: {
       \\"asset-pipe-test-es5c\\":
-        \\"155c2235c68a81d7df2f9bfb79149d679bf187c69e815d8c5c4fa3d5def2ad3b\\"
+        \\"67aa820392d57ad7d93c384df468b87452a4ab89ea3e322a70b1dbb4350ce339\\"
     },
     file: \\"asset-pipe-js-writer/node_modules/asset-pipe-test-es5b/main.js\\",
     index: 3,
@@ -258,7 +258,7 @@ exports[`options object passes options on to browserify 1`] = `
     sourceFile: \\"node_modules/asset-pipe-test-es5b/main.js\\"
   },
   {
-    id: \\"155c2235c68a81d7df2f9bfb79149d679bf187c69e815d8c5c4fa3d5def2ad3b\\",
+    id: \\"67aa820392d57ad7d93c384df468b87452a4ab89ea3e322a70b1dbb4350ce339\\",
     source:
       \\"'use strict';\\\\n\\\\n function prime (num) {\\\\n    if (num < 4) {\\\\n        return true;\\\\n    }\\\\n    var max = Math.ceil(Math.sqrt(num));\\\\n    for (var i = 2; i <= max; i++) {\\\\n        if (num % i === 0) {\\\\n            return false;\\\\n        }\\\\n    }\\\\n    return true;\\\\n};\\\\n\\\\nmodule.exports = prime;\\\\n\\",
     deps: {},
@@ -272,13 +272,13 @@ exports[`options object passes options on to browserify 1`] = `
     entry: true,
     expose: false,
     file: \\"asset-pipe-js-writer/test/mock/main.js\\",
-    id: \\"ba83602a6ebf462378a3dd0ad7ad8c8ef9b45d6968362609d44c75b9e48f2847\\",
+    id: \\"eae04b1ae2a4f9822b36015cb458186dcec69821e785f796f243d2ad994dd768\\",
     order: 0,
     source:
       \\"'use strict';\\\\n\\\\nrequire('asset-pipe-test-es5a');\\\\nconsole.log('main says hello');\\\\n\\",
     deps: {
       \\"asset-pipe-test-es5a\\":
-        \\"18b899957f7b0dfbb0e7ab22606904ffea55126f338efca91203c4df2f8d76ad\\"
+        \\"da34d0ca36dc47074b9f140adea29001e5dd86f6457e27f91134f1f7de8eb094\\"
     },
     index: 5,
     indexDeps: {
@@ -294,14 +294,14 @@ exports[`options object passes options on to browserify 1`] = `
 exports[`writer produces a feed of dependencies with ids hashed 1`] = `
 "[
   {
-    id: \\"18b899957f7b0dfbb0e7ab22606904ffea55126f338efca91203c4df2f8d76ad\\",
+    id: \\"da34d0ca36dc47074b9f140adea29001e5dd86f6457e27f91134f1f7de8eb094\\",
     source:
       \\"'use strict';\\\\n\\\\nvar fizzbuzz = require('asset-pipe-test-es5b');\\\\nvar util = require('./util.js');\\\\n\\\\nconsole.log(util.helloWorld());\\\\nconsole.log(util.helloNumber());\\\\nfizzbuzz({s:4, e:20}, function (mgs) {\\\\n    console.log(mgs);\\\\n});\\\\n\\",
     deps: {
       \\"./util.js\\":
-        \\"e2d2292212a0dcea8006331903fe562b9ac3eb46148bdfd3836273fd9a7db609\\",
+        \\"69cb155d3e533cc9c8c419cc89f27ca6c0a34fdefa889754a06e8ec68541ac04\\",
       \\"asset-pipe-test-es5b\\":
-        \\"110e7030dde4afcbbc598c046f76700ab7eb851a52709f3086b2d60c31330087\\"
+        \\"427feef8cc6bd1678b92f1049b2df0d23a024b968fda0796fada3e67e6f9f35b\\"
     },
     file: \\"asset-pipe-js-writer/node_modules/asset-pipe-test-es5a/lib/main.js\\",
     index: 1,
@@ -311,12 +311,12 @@ exports[`writer produces a feed of dependencies with ids hashed 1`] = `
     }
   },
   {
-    id: \\"e2d2292212a0dcea8006331903fe562b9ac3eb46148bdfd3836273fd9a7db609\\",
+    id: \\"69cb155d3e533cc9c8c419cc89f27ca6c0a34fdefa889754a06e8ec68541ac04\\",
     source:
       \\"'use strict';\\\\n\\\\nvar isPrime = require('asset-pipe-test-es5c');\\\\n\\\\nfunction hello() {\\\\n    return 'Hello world!';\\\\n}\\\\n\\\\nfunction numb(num) {\\\\n    if (isPrime(num)) {\\\\n        return 'Not a prime number';\\\\n    }\\\\n    return 'A prime number';\\\\n}\\\\n\\\\nmodule.exports.helloWorld = hello;\\\\nmodule.exports.helloNumber = numb;\\\\n\\",
     deps: {
       \\"asset-pipe-test-es5c\\":
-        \\"155c2235c68a81d7df2f9bfb79149d679bf187c69e815d8c5c4fa3d5def2ad3b\\"
+        \\"67aa820392d57ad7d93c384df468b87452a4ab89ea3e322a70b1dbb4350ce339\\"
     },
     file: \\"asset-pipe-js-writer/node_modules/asset-pipe-test-es5a/lib/util.js\\",
     index: 2,
@@ -325,12 +325,12 @@ exports[`writer produces a feed of dependencies with ids hashed 1`] = `
     }
   },
   {
-    id: \\"110e7030dde4afcbbc598c046f76700ab7eb851a52709f3086b2d60c31330087\\",
+    id: \\"427feef8cc6bd1678b92f1049b2df0d23a024b968fda0796fada3e67e6f9f35b\\",
     source:
       \\"'use strict';\\\\n\\\\nvar isPrime = require('asset-pipe-test-es5c');\\\\n\\\\n/**\\\\n * Run through FizzBuzz for n integers\\\\n *\\\\n * @param {Number} config.s The number to start at\\\\n * @param {Number} config.e The number to end at\\\\n * @param {function} callback\\\\n */\\\\n\\\\nfunction fizzbuzz (config, callback) {\\\\n    for (var i = config.s; i <= config.e; i++) {\\\\n        var prime = '';\\\\n        if (config.p && isPrime(i)) {\\\\n            prime = ' Prime';\\\\n        }\\\\n\\\\n        if (!(i % 15)) {\\\\n            callback('FizzBuzz');\\\\n            continue;\\\\n        } else if (!(i % 3)) {\\\\n            callback('Fizz' + prime);\\\\n            continue;\\\\n        } else if (!(i % 5)) {\\\\n            callback('Buzz' + prime);\\\\n            continue;\\\\n        }\\\\n        callback(prime.trim() || i);\\\\n    }\\\\n};\\\\n\\\\nmodule.exports = fizzbuzz;\\\\n\\",
     deps: {
       \\"asset-pipe-test-es5c\\":
-        \\"155c2235c68a81d7df2f9bfb79149d679bf187c69e815d8c5c4fa3d5def2ad3b\\"
+        \\"67aa820392d57ad7d93c384df468b87452a4ab89ea3e322a70b1dbb4350ce339\\"
     },
     file: \\"asset-pipe-js-writer/node_modules/asset-pipe-test-es5b/main.js\\",
     index: 3,
@@ -339,7 +339,7 @@ exports[`writer produces a feed of dependencies with ids hashed 1`] = `
     }
   },
   {
-    id: \\"155c2235c68a81d7df2f9bfb79149d679bf187c69e815d8c5c4fa3d5def2ad3b\\",
+    id: \\"67aa820392d57ad7d93c384df468b87452a4ab89ea3e322a70b1dbb4350ce339\\",
     source:
       \\"'use strict';\\\\n\\\\n function prime (num) {\\\\n    if (num < 4) {\\\\n        return true;\\\\n    }\\\\n    var max = Math.ceil(Math.sqrt(num));\\\\n    for (var i = 2; i <= max; i++) {\\\\n        if (num % i === 0) {\\\\n            return false;\\\\n        }\\\\n    }\\\\n    return true;\\\\n};\\\\n\\\\nmodule.exports = prime;\\\\n\\",
     deps: {},
@@ -351,13 +351,13 @@ exports[`writer produces a feed of dependencies with ids hashed 1`] = `
     entry: true,
     expose: false,
     file: \\"asset-pipe-js-writer/test/mock/main.js\\",
-    id: \\"ba83602a6ebf462378a3dd0ad7ad8c8ef9b45d6968362609d44c75b9e48f2847\\",
+    id: \\"eae04b1ae2a4f9822b36015cb458186dcec69821e785f796f243d2ad994dd768\\",
     order: 0,
     source:
       \\"'use strict';\\\\n\\\\nrequire('asset-pipe-test-es5a');\\\\nconsole.log('main says hello');\\\\n\\",
     deps: {
       \\"asset-pipe-test-es5a\\":
-        \\"18b899957f7b0dfbb0e7ab22606904ffea55126f338efca91203c4df2f8d76ad\\"
+        \\"da34d0ca36dc47074b9f140adea29001e5dd86f6457e27f91134f1f7de8eb094\\"
     },
     index: 5,
     indexDeps: {

--- a/test/mock/identical-implementation/index.js
+++ b/test/mock/identical-implementation/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const entries = require('object.entries');
+const values = require('object.values');
+
+const obj = { one: 1, two: 2, three: 3 };
+
+console.log(entries(obj));
+console.log(values(obj));

--- a/test/mock/identical-implementation/node_modules/define-properties/index.js
+++ b/test/mock/identical-implementation/node_modules/define-properties/index.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const keys = require('object-keys');
+const foreach = require('foreach');
+const hasSymbols = typeof Symbol === 'function' && typeof Symbol() === 'symbol';
+
+const toStr = Object.prototype.toString;
+
+const isFunction = function(fn) {
+    return typeof fn === 'function' && toStr.call(fn) === '[object Function]';
+};
+
+const arePropertyDescriptorsSupported = function() {
+    const obj = {};
+    try {
+        Object.defineProperty(obj, 'x', { enumerable: false, value: obj });
+        /* eslint-disable no-unused-vars, no-restricted-syntax */
+        for (const _ in obj) {
+            return false;
+        }
+        /* eslint-enable no-unused-vars, no-restricted-syntax */
+        return obj.x === obj;
+    } catch (e) {
+        /* this is IE 8. */
+        return false;
+    }
+};
+const supportsDescriptors =
+    Object.defineProperty && arePropertyDescriptorsSupported();
+
+const defineProperty = function(object, name, value, predicate) {
+    if (name in object && (!isFunction(predicate) || !predicate())) {
+        return;
+    }
+    if (supportsDescriptors) {
+        Object.defineProperty(object, name, {
+            configurable: true,
+            enumerable: false,
+            value,
+            writable: true,
+        });
+    } else {
+        object[name] = value;
+    }
+};
+
+const defineProperties = function(object, map) {
+    const predicates = arguments.length > 2 ? arguments[2] : {};
+    let props = keys(map);
+    if (hasSymbols) {
+        props = props.concat(Object.getOwnPropertySymbols(map));
+    }
+    foreach(props, name => {
+        defineProperty(object, name, map[name], predicates[name]);
+    });
+};
+
+defineProperties.supportsDescriptors = !!supportsDescriptors;
+
+module.exports = defineProperties;

--- a/test/mock/identical-implementation/node_modules/define-properties/package.json
+++ b/test/mock/identical-implementation/node_modules/define-properties/package.json
@@ -1,0 +1,97 @@
+{
+  "_from": "define-properties@^1.1.2",
+  "_id": "define-properties@1.1.2",
+  "_inBundle": false,
+  "_integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+  "_location": "/define-properties",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "range",
+    "registry": true,
+    "raw": "define-properties@^1.1.2",
+    "name": "define-properties",
+    "escapedName": "define-properties",
+    "rawSpec": "^1.1.2",
+    "saveSpec": null,
+    "fetchSpec": "^1.1.2"
+  },
+  "_requiredBy": [
+    "/object.entries",
+    "/object.values"
+  ],
+  "_resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+  "_shasum": "83a73f2fea569898fb737193c8f873caf6d45c94",
+  "_spec": "define-properties@^1.1.2",
+  "_where": "/Users/ricwalke/src/asset-pipe/asset-pipe-js-writer/test/mock/identical-implementation/node_modules/object.entries",
+  "author": {
+    "name": "Jordan Harband"
+  },
+  "bugs": {
+    "url": "https://github.com/ljharb/define-properties/issues"
+  },
+  "bundleDependencies": false,
+  "dependencies": {
+    "foreach": "^2.0.5",
+    "object-keys": "^1.0.8"
+  },
+  "deprecated": false,
+  "description": "Define multiple non-enumerable properties at once. Uses `Object.defineProperty` when available; falls back to standard assignment in older engines.",
+  "devDependencies": {
+    "@ljharb/eslint-config": "^1.3.0",
+    "covert": "^1.1.0",
+    "editorconfig-tools": "^0.1.1",
+    "eslint": "^1.6.0",
+    "jscs": "^2.3.1",
+    "nsp": "^1.1.0",
+    "tape": "^4.2.1"
+  },
+  "engines": {
+    "node": ">= 0.4"
+  },
+  "homepage": "https://github.com/ljharb/define-properties#readme",
+  "keywords": [
+    "Object.defineProperty",
+    "Object.defineProperties",
+    "object",
+    "property descriptor",
+    "descriptor",
+    "define",
+    "ES5"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "name": "define-properties",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ljharb/define-properties.git"
+  },
+  "scripts": {
+    "coverage": "covert test/*.js",
+    "coverage-quiet": "covert test/*.js --quiet",
+    "eccheck": "editorconfig-tools check *.js **/*.js > /dev/null",
+    "eslint": "eslint test/*.js *.js",
+    "jscs": "jscs test/*.js *.js",
+    "lint": "npm run jscs && npm run eslint",
+    "security": "nsp package",
+    "test": "npm run lint && node test/index.js && npm run security"
+  },
+  "testling": {
+    "files": "test/index.js",
+    "browsers": [
+      "iexplore/6.0..latest",
+      "firefox/3.0..6.0",
+      "firefox/15.0..latest",
+      "firefox/nightly",
+      "chrome/4.0..10.0",
+      "chrome/20.0..latest",
+      "chrome/canary",
+      "opera/10.0..latest",
+      "opera/next",
+      "safari/4.0..latest",
+      "ipad/6.0..latest",
+      "iphone/6.0..latest",
+      "android-browser/4.2"
+    ]
+  },
+  "version": "1.1.2"
+}

--- a/test/mock/identical-implementation/node_modules/es-abstract/es2015.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/es2015.js
@@ -1,0 +1,625 @@
+'use strict';
+
+const has = require('has');
+const toPrimitive = require('es-to-primitive/es6');
+
+const toStr = Object.prototype.toString;
+const hasSymbols =
+    typeof Symbol === 'function' && typeof Symbol.iterator === 'symbol';
+
+const $isNaN = require('./helpers/isNaN');
+const $isFinite = require('./helpers/isFinite');
+const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER || Math.pow(2, 53) - 1;
+
+const assign = require('./helpers/assign');
+const sign = require('./helpers/sign');
+const mod = require('./helpers/mod');
+const isPrimitive = require('./helpers/isPrimitive');
+const parseInteger = parseInt;
+const bind = require('function-bind');
+const arraySlice = bind.call(Function.call, Array.prototype.slice);
+const strSlice = bind.call(Function.call, String.prototype.slice);
+const isBinary = bind.call(Function.call, RegExp.prototype.test, /^0b[01]+$/i);
+const isOctal = bind.call(Function.call, RegExp.prototype.test, /^0o[0-7]+$/i);
+const regexExec = bind.call(Function.call, RegExp.prototype.exec);
+const nonWS = ['\u0085', '\u200b', '\ufffe'].join('');
+const nonWSregex = new RegExp(`[${nonWS}]`, 'g');
+const hasNonWS = bind.call(Function.call, RegExp.prototype.test, nonWSregex);
+const invalidHexLiteral = /^[-+]0x[0-9a-f]+$/i;
+const isInvalidHexLiteral = bind.call(
+    Function.call,
+    RegExp.prototype.test,
+    invalidHexLiteral
+);
+
+// whitespace from: http://es5.github.io/#x15.5.4.20
+// implementation from https://github.com/es-shims/es5-shim/blob/v3.4.0/es5-shim.js#L1304-L1324
+const ws = [
+    '\x09\x0A\x0B\x0C\x0D\x20\xA0\u1680\u180E\u2000\u2001\u2002\u2003',
+    '\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028',
+    '\u2029\uFEFF',
+].join('');
+const trimRegex = new RegExp(`(^[${ws}]+)|([${ws}]+$)`, 'g');
+const replace = bind.call(Function.call, String.prototype.replace);
+const trim = function(value) {
+    return replace(value, trimRegex, '');
+};
+
+const ES5 = require('./es5');
+
+const hasRegExpMatcher = require('is-regex');
+
+// https://people.mozilla.org/~jorendorff/es6-draft.html#sec-abstract-operations
+const ES6 = assign(assign({}, ES5), {
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-call-f-v-args
+    Call: function Call(F, V) {
+        const args = arguments.length > 2 ? arguments[2] : [];
+        if (!this.IsCallable(F)) {
+            throw new TypeError(`${F} is not a function`);
+        }
+        return F.apply(V, args);
+    },
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-toprimitive
+    ToPrimitive: toPrimitive,
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-toboolean
+    // ToBoolean: ES5.ToBoolean,
+
+    // http://www.ecma-international.org/ecma-262/6.0/#sec-tonumber
+    ToNumber: function ToNumber(argument) {
+        const value = isPrimitive(argument)
+            ? argument
+            : toPrimitive(argument, Number);
+        if (typeof value === 'symbol') {
+            throw new TypeError('Cannot convert a Symbol value to a number');
+        }
+        if (typeof value === 'string') {
+            if (isBinary(value)) {
+                return this.ToNumber(parseInteger(strSlice(value, 2), 2));
+            } else if (isOctal(value)) {
+                return this.ToNumber(parseInteger(strSlice(value, 2), 8));
+            } else if (hasNonWS(value) || isInvalidHexLiteral(value)) {
+                return NaN;
+            } else {
+                const trimmed = trim(value);
+                if (trimmed !== value) {
+                    return this.ToNumber(trimmed);
+                }
+            }
+        }
+        return Number(value);
+    },
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-tointeger
+    // ToInteger: ES5.ToNumber,
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-toint32
+    // ToInt32: ES5.ToInt32,
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-touint32
+    // ToUint32: ES5.ToUint32,
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-toint16
+    ToInt16: function ToInt16(argument) {
+        const int16bit = this.ToUint16(argument);
+        return int16bit >= 0x8000 ? int16bit - 0x10000 : int16bit;
+    },
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-touint16
+    // ToUint16: ES5.ToUint16,
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-toint8
+    ToInt8: function ToInt8(argument) {
+        const int8bit = this.ToUint8(argument);
+        return int8bit >= 0x80 ? int8bit - 0x100 : int8bit;
+    },
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-touint8
+    ToUint8: function ToUint8(argument) {
+        const number = this.ToNumber(argument);
+        if ($isNaN(number) || number === 0 || !$isFinite(number)) {
+            return 0;
+        }
+        const posInt = sign(number) * Math.floor(Math.abs(number));
+        return mod(posInt, 0x100);
+    },
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-touint8clamp
+    ToUint8Clamp: function ToUint8Clamp(argument) {
+        const number = this.ToNumber(argument);
+        if ($isNaN(number) || number <= 0) {
+            return 0;
+        }
+        if (number >= 0xff) {
+            return 0xff;
+        }
+        const f = Math.floor(argument);
+        if (f + 0.5 < number) {
+            return f + 1;
+        }
+        if (number < f + 0.5) {
+            return f;
+        }
+        if (f % 2 !== 0) {
+            return f + 1;
+        }
+        return f;
+    },
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-tostring
+    ToString: function ToString(argument) {
+        if (typeof argument === 'symbol') {
+            throw new TypeError('Cannot convert a Symbol value to a string');
+        }
+        return String(argument);
+    },
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-toobject
+    ToObject: function ToObject(value) {
+        this.RequireObjectCoercible(value);
+        return Object(value);
+    },
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-topropertykey
+    ToPropertyKey: function ToPropertyKey(argument) {
+        const key = this.ToPrimitive(argument, String);
+        return typeof key === 'symbol' ? key : this.ToString(key);
+    },
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-tolength
+    ToLength: function ToLength(argument) {
+        const len = this.ToInteger(argument);
+        if (len <= 0) {
+            return 0;
+        } // includes converting -0 to +0
+        if (len > MAX_SAFE_INTEGER) {
+            return MAX_SAFE_INTEGER;
+        }
+        return len;
+    },
+
+    // http://www.ecma-international.org/ecma-262/6.0/#sec-canonicalnumericindexstring
+    CanonicalNumericIndexString: function CanonicalNumericIndexString(
+        argument
+    ) {
+        if (toStr.call(argument) !== '[object String]') {
+            throw new TypeError('must be a string');
+        }
+        if (argument === '-0') {
+            return -0;
+        }
+        const n = this.ToNumber(argument);
+        if (this.SameValue(this.ToString(n), argument)) {
+            return n;
+        }
+        return void 0;
+    },
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-requireobjectcoercible
+    RequireObjectCoercible: ES5.CheckObjectCoercible,
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-isarray
+    IsArray:
+        Array.isArray ||
+        function IsArray(argument) {
+            return toStr.call(argument) === '[object Array]';
+        },
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-iscallable
+    // IsCallable: ES5.IsCallable,
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-isconstructor
+    IsConstructor: function IsConstructor(argument) {
+        return typeof argument === 'function' && !!argument.prototype; // unfortunately there's no way to truly check this without try/catch `new argument`
+    },
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-isextensible-o
+    IsExtensible: function IsExtensible(obj) {
+        if (!Object.preventExtensions) {
+            return true;
+        }
+        if (isPrimitive(obj)) {
+            return false;
+        }
+        return Object.isExtensible(obj);
+    },
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-isinteger
+    IsInteger: function IsInteger(argument) {
+        if (
+            typeof argument !== 'number' ||
+            $isNaN(argument) ||
+            !$isFinite(argument)
+        ) {
+            return false;
+        }
+        const abs = Math.abs(argument);
+        return Math.floor(abs) === abs;
+    },
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-ispropertykey
+    IsPropertyKey: function IsPropertyKey(argument) {
+        return typeof argument === 'string' || typeof argument === 'symbol';
+    },
+
+    // http://www.ecma-international.org/ecma-262/6.0/#sec-isregexp
+    IsRegExp: function IsRegExp(argument) {
+        if (!argument || typeof argument !== 'object') {
+            return false;
+        }
+        if (hasSymbols) {
+            const isRegExp = argument[Symbol.match];
+            if (typeof isRegExp !== 'undefined') {
+                return ES5.ToBoolean(isRegExp);
+            }
+        }
+        return hasRegExpMatcher(argument);
+    },
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-samevalue
+    // SameValue: ES5.SameValue,
+
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-samevaluezero
+    SameValueZero: function SameValueZero(x, y) {
+        return x === y || ($isNaN(x) && $isNaN(y));
+    },
+
+    /**
+     * 7.3.2 GetV (V, P)
+     * 1. Assert: IsPropertyKey(P) is true.
+     * 2. Let O be ToObject(V).
+     * 3. ReturnIfAbrupt(O).
+     * 4. Return O.[[Get]](P, V).
+     */
+    GetV: function GetV(V, P) {
+        // 7.3.2.1
+        if (!this.IsPropertyKey(P)) {
+            throw new TypeError(
+                'Assertion failed: IsPropertyKey(P) is not true'
+            );
+        }
+
+        // 7.3.2.2-3
+        const O = this.ToObject(V);
+
+        // 7.3.2.4
+        return O[P];
+    },
+
+    /**
+     * 7.3.9 - http://www.ecma-international.org/ecma-262/6.0/#sec-getmethod
+     * 1. Assert: IsPropertyKey(P) is true.
+     * 2. Let func be GetV(O, P).
+     * 3. ReturnIfAbrupt(func).
+     * 4. If func is either undefined or null, return undefined.
+     * 5. If IsCallable(func) is false, throw a TypeError exception.
+     * 6. Return func.
+     */
+    GetMethod: function GetMethod(O, P) {
+        // 7.3.9.1
+        if (!this.IsPropertyKey(P)) {
+            throw new TypeError(
+                'Assertion failed: IsPropertyKey(P) is not true'
+            );
+        }
+
+        // 7.3.9.2
+        const func = this.GetV(O, P);
+
+        // 7.3.9.4
+        if (func == null) {
+            return void 0;
+        }
+
+        // 7.3.9.5
+        if (!this.IsCallable(func)) {
+            throw new TypeError(`${P}is not a function`);
+        }
+
+        // 7.3.9.6
+        return func;
+    },
+
+    /**
+     * 7.3.1 Get (O, P) - http://www.ecma-international.org/ecma-262/6.0/#sec-get-o-p
+     * 1. Assert: Type(O) is Object.
+     * 2. Assert: IsPropertyKey(P) is true.
+     * 3. Return O.[[Get]](P, O).
+     */
+    Get: function Get(O, P) {
+        // 7.3.1.1
+        if (this.Type(O) !== 'Object') {
+            throw new TypeError('Assertion failed: Type(O) is not Object');
+        }
+        // 7.3.1.2
+        if (!this.IsPropertyKey(P)) {
+            throw new TypeError(
+                'Assertion failed: IsPropertyKey(P) is not true'
+            );
+        }
+        // 7.3.1.3
+        return O[P];
+    },
+
+    Type: function Type(x) {
+        if (typeof x === 'symbol') {
+            return 'Symbol';
+        }
+        return ES5.Type(x);
+    },
+
+    // http://www.ecma-international.org/ecma-262/6.0/#sec-speciesconstructor
+    SpeciesConstructor: function SpeciesConstructor(O, defaultConstructor) {
+        if (this.Type(O) !== 'Object') {
+            throw new TypeError('Assertion failed: Type(O) is not Object');
+        }
+        const C = O.constructor;
+        if (typeof C === 'undefined') {
+            return defaultConstructor;
+        }
+        if (this.Type(C) !== 'Object') {
+            throw new TypeError('O.constructor is not an Object');
+        }
+        const S = hasSymbols && Symbol.species ? C[Symbol.species] : void 0;
+        if (S == null) {
+            return defaultConstructor;
+        }
+        if (this.IsConstructor(S)) {
+            return S;
+        }
+        throw new TypeError('no constructor found');
+    },
+
+    // http://ecma-international.org/ecma-262/6.0/#sec-completepropertydescriptor
+    CompletePropertyDescriptor: function CompletePropertyDescriptor(Desc) {
+        if (!this.IsPropertyDescriptor(Desc)) {
+            throw new TypeError('Desc must be a Property Descriptor');
+        }
+
+        if (this.IsGenericDescriptor(Desc) || this.IsDataDescriptor(Desc)) {
+            if (!has(Desc, '[[Value]]')) {
+                Desc['[[Value]]'] = void 0;
+            }
+            if (!has(Desc, '[[Writable]]')) {
+                Desc['[[Writable]]'] = false;
+            }
+        } else {
+            if (!has(Desc, '[[Get]]')) {
+                Desc['[[Get]]'] = void 0;
+            }
+            if (!has(Desc, '[[Set]]')) {
+                Desc['[[Set]]'] = void 0;
+            }
+        }
+        if (!has(Desc, '[[Enumerable]]')) {
+            Desc['[[Enumerable]]'] = false;
+        }
+        if (!has(Desc, '[[Configurable]]')) {
+            Desc['[[Configurable]]'] = false;
+        }
+        return Desc;
+    },
+
+    // http://ecma-international.org/ecma-262/6.0/#sec-set-o-p-v-throw
+    Set: function Set(O, P, V, Throw) {
+        if (this.Type(O) !== 'Object') {
+            throw new TypeError('O must be an Object');
+        }
+        if (!this.IsPropertyKey(P)) {
+            throw new TypeError('P must be a Property Key');
+        }
+        if (this.Type(Throw) !== 'Boolean') {
+            throw new TypeError('Throw must be a Boolean');
+        }
+        if (Throw) {
+            O[P] = V;
+            return true;
+        } else {
+            try {
+                O[P] = V;
+            } catch (e) {
+                return false;
+            }
+        }
+    },
+
+    // http://ecma-international.org/ecma-262/6.0/#sec-hasownproperty
+    HasOwnProperty: function HasOwnProperty(O, P) {
+        if (this.Type(O) !== 'Object') {
+            throw new TypeError('O must be an Object');
+        }
+        if (!this.IsPropertyKey(P)) {
+            throw new TypeError('P must be a Property Key');
+        }
+        return has(O, P);
+    },
+
+    // http://ecma-international.org/ecma-262/6.0/#sec-hasproperty
+    HasProperty: function HasProperty(O, P) {
+        if (this.Type(O) !== 'Object') {
+            throw new TypeError('O must be an Object');
+        }
+        if (!this.IsPropertyKey(P)) {
+            throw new TypeError('P must be a Property Key');
+        }
+        return P in O;
+    },
+
+    // http://ecma-international.org/ecma-262/6.0/#sec-isconcatspreadable
+    IsConcatSpreadable: function IsConcatSpreadable(O) {
+        if (this.Type(O) !== 'Object') {
+            return false;
+        }
+        if (hasSymbols && typeof Symbol.isConcatSpreadable === 'symbol') {
+            const spreadable = this.Get(O, Symbol.isConcatSpreadable);
+            if (typeof spreadable !== 'undefined') {
+                return this.ToBoolean(spreadable);
+            }
+        }
+        return this.IsArray(O);
+    },
+
+    // http://ecma-international.org/ecma-262/6.0/#sec-invoke
+    Invoke: function Invoke(O, P) {
+        if (!this.IsPropertyKey(P)) {
+            throw new TypeError('P must be a Property Key');
+        }
+        const argumentsList = arraySlice(arguments, 2);
+        const func = this.GetV(O, P);
+        return this.Call(func, O, argumentsList);
+    },
+
+    // http://ecma-international.org/ecma-262/6.0/#sec-createiterresultobject
+    CreateIterResultObject: function CreateIterResultObject(value, done) {
+        if (this.Type(done) !== 'Boolean') {
+            throw new TypeError('Assertion failed: Type(done) is not Boolean');
+        }
+        return {
+            value,
+            done,
+        };
+    },
+
+    // http://ecma-international.org/ecma-262/6.0/#sec-regexpexec
+    RegExpExec: function RegExpExec(R, S) {
+        if (this.Type(R) !== 'Object') {
+            throw new TypeError('R must be an Object');
+        }
+        if (this.Type(S) !== 'String') {
+            throw new TypeError('S must be a String');
+        }
+        const exec = this.Get(R, 'exec');
+        if (this.IsCallable(exec)) {
+            const result = this.Call(exec, R, [S]);
+            if (result === null || this.Type(result) === 'Object') {
+                return result;
+            }
+            throw new TypeError(
+                '"exec" method must return `null` or an Object'
+            );
+        }
+        return regexExec(R, S);
+    },
+
+    // http://ecma-international.org/ecma-262/6.0/#sec-arrayspeciescreate
+    ArraySpeciesCreate: function ArraySpeciesCreate(originalArray, length) {
+        if (!this.IsInteger(length) || length < 0) {
+            throw new TypeError(
+                'Assertion failed: length must be an integer >= 0'
+            );
+        }
+        const len = length === 0 ? 0 : length;
+        let C;
+        const isArray = this.IsArray(originalArray);
+        if (isArray) {
+            C = this.Get(originalArray, 'constructor');
+            // TODO: figure out how to make a cross-realm normal Array, a same-realm Array
+            // if (this.IsConstructor(C)) {
+            // 	if C is another realm's Array, C = undefined
+            // 	Object.getPrototypeOf(Object.getPrototypeOf(Object.getPrototypeOf(Array))) === null ?
+            // }
+            if (this.Type(C) === 'Object' && hasSymbols && Symbol.species) {
+                C = this.Get(C, Symbol.species);
+                if (C === null) {
+                    C = void 0;
+                }
+            }
+        }
+        if (typeof C === 'undefined') {
+            return Array(len);
+        }
+        if (!this.IsConstructor(C)) {
+            throw new TypeError('C must be a constructor');
+        }
+        return new C(len); // this.Construct(C, len);
+    },
+
+    CreateDataProperty: function CreateDataProperty(O, P, V) {
+        if (this.Type(O) !== 'Object') {
+            throw new TypeError('Assertion failed: Type(O) is not Object');
+        }
+        if (!this.IsPropertyKey(P)) {
+            throw new TypeError(
+                'Assertion failed: IsPropertyKey(P) is not true'
+            );
+        }
+        const oldDesc = Object.getOwnPropertyDescriptor(O, P);
+        const extensible =
+            oldDesc ||
+            (typeof Object.isExtensible !== 'function' ||
+                Object.isExtensible(O));
+        const immutable =
+            oldDesc && (!oldDesc.writable || !oldDesc.configurable);
+        if (immutable || !extensible) {
+            return false;
+        }
+        const newDesc = {
+            configurable: true,
+            enumerable: true,
+            value: V,
+            writable: true,
+        };
+        Object.defineProperty(O, P, newDesc);
+        return true;
+    },
+
+    // http://ecma-international.org/ecma-262/6.0/#sec-createdatapropertyorthrow
+    CreateDataPropertyOrThrow: function CreateDataPropertyOrThrow(O, P, V) {
+        if (this.Type(O) !== 'Object') {
+            throw new TypeError('Assertion failed: Type(O) is not Object');
+        }
+        if (!this.IsPropertyKey(P)) {
+            throw new TypeError(
+                'Assertion failed: IsPropertyKey(P) is not true'
+            );
+        }
+        const success = this.CreateDataProperty(O, P, V);
+        if (!success) {
+            throw new TypeError('unable to create data property');
+        }
+        return success;
+    },
+
+    // http://ecma-international.org/ecma-262/6.0/#sec-advancestringindex
+    AdvanceStringIndex: function AdvanceStringIndex(S, index, unicode) {
+        if (this.Type(S) !== 'String') {
+            throw new TypeError('Assertion failed: Type(S) is not String');
+        }
+        if (!this.IsInteger(index)) {
+            throw new TypeError(
+                'Assertion failed: length must be an integer >= 0 and <= (2**53 - 1)'
+            );
+        }
+        if (index < 0 || index > MAX_SAFE_INTEGER) {
+            throw new RangeError(
+                'Assertion failed: length must be an integer >= 0 and <= (2**53 - 1)'
+            );
+        }
+        if (this.Type(unicode) !== 'Boolean') {
+            throw new TypeError(
+                'Assertion failed: Type(unicode) is not Boolean'
+            );
+        }
+        if (!unicode) {
+            return index + 1;
+        }
+        const length = S.length;
+        if (index + 1 >= length) {
+            return index + 1;
+        }
+        const first = S.charCodeAt(index);
+        if (first < 0xd800 || first > 0xdbff) {
+            return index + 1;
+        }
+        const second = S.charCodeAt(index + 1);
+        if (second < 0xdc00 || second > 0xdfff) {
+            return index + 1;
+        }
+        return index + 2;
+    },
+});
+
+delete ES6.CheckObjectCoercible; // renamed in ES6 to RequireObjectCoercible
+
+module.exports = ES6;

--- a/test/mock/identical-implementation/node_modules/es-abstract/es2016.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/es2016.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const ES2015 = require('./es2015');
+const assign = require('./helpers/assign');
+
+const ES2016 = assign(assign({}, ES2015), {
+    // https://github.com/tc39/ecma262/pull/60
+    SameValueNonNumber: function SameValueNonNumber(x, y) {
+        if (typeof x === 'number' || typeof x !== typeof y) {
+            throw new TypeError(
+                'SameValueNonNumber requires two non-number values of the same type.'
+            );
+        }
+        return this.SameValue(x, y);
+    },
+});
+
+module.exports = ES2016;

--- a/test/mock/identical-implementation/node_modules/es-abstract/es2017.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/es2017.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const ES2016 = require('./es2016');
+const assign = require('./helpers/assign');
+
+const ES2017 = assign(assign({}, ES2016), {
+    ToIndex: function ToIndex(value) {
+        if (typeof value === 'undefined') {
+            return 0;
+        }
+        const integerIndex = this.ToInteger(value);
+        if (integerIndex < 0) {
+            throw new RangeError('index must be >= 0');
+        }
+        const index = this.ToLength(integerIndex);
+        if (!this.SameValueZero(integerIndex, index)) {
+            throw new RangeError('index must be >= 0 and < 2 ** 53 - 1');
+        }
+        return index;
+    },
+});
+
+delete ES2017.EnumerableOwnNames; // replaced with EnumerableOwnProperties
+
+module.exports = ES2017;

--- a/test/mock/identical-implementation/node_modules/es-abstract/es5.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/es5.js
@@ -1,0 +1,254 @@
+'use strict';
+
+const $isNaN = require('./helpers/isNaN');
+const $isFinite = require('./helpers/isFinite');
+
+const sign = require('./helpers/sign');
+const mod = require('./helpers/mod');
+
+const IsCallable = require('is-callable');
+const toPrimitive = require('es-to-primitive/es5');
+
+const has = require('has');
+
+// https://es5.github.io/#x9
+const ES5 = {
+    ToPrimitive: toPrimitive,
+
+    ToBoolean: function ToBoolean(value) {
+        return !!value;
+    },
+    ToNumber: function ToNumber(value) {
+        return Number(value);
+    },
+    ToInteger: function ToInteger(value) {
+        const number = this.ToNumber(value);
+        if ($isNaN(number)) {
+            return 0;
+        }
+        if (number === 0 || !$isFinite(number)) {
+            return number;
+        }
+        return sign(number) * Math.floor(Math.abs(number));
+    },
+    ToInt32: function ToInt32(x) {
+        return this.ToNumber(x) >> 0;
+    },
+    ToUint32: function ToUint32(x) {
+        return this.ToNumber(x) >>> 0;
+    },
+    ToUint16: function ToUint16(value) {
+        const number = this.ToNumber(value);
+        if ($isNaN(number) || number === 0 || !$isFinite(number)) {
+            return 0;
+        }
+        const posInt = sign(number) * Math.floor(Math.abs(number));
+        return mod(posInt, 0x10000);
+    },
+    ToString: function ToString(value) {
+        return String(value);
+    },
+    ToObject: function ToObject(value) {
+        this.CheckObjectCoercible(value);
+        return Object(value);
+    },
+    CheckObjectCoercible: function CheckObjectCoercible(value, optMessage) {
+        /* jshint eqnull:true */
+        if (value == null) {
+            throw new TypeError(optMessage || `Cannot call method on ${value}`);
+        }
+        return value;
+    },
+    IsCallable,
+    SameValue: function SameValue(x, y) {
+        if (x === y) {
+            // 0 === -0, but they are not identical.
+            if (x === 0) {
+                return 1 / x === 1 / y;
+            }
+            return true;
+        }
+        return $isNaN(x) && $isNaN(y);
+    },
+
+    // http://www.ecma-international.org/ecma-262/5.1/#sec-8
+    Type: function Type(x) {
+        if (x === null) {
+            return 'Null';
+        }
+        if (typeof x === 'undefined') {
+            return 'Undefined';
+        }
+        if (typeof x === 'function' || typeof x === 'object') {
+            return 'Object';
+        }
+        if (typeof x === 'number') {
+            return 'Number';
+        }
+        if (typeof x === 'boolean') {
+            return 'Boolean';
+        }
+        if (typeof x === 'string') {
+            return 'String';
+        }
+    },
+
+    // http://ecma-international.org/ecma-262/6.0/#sec-property-descriptor-specification-type
+    IsPropertyDescriptor: function IsPropertyDescriptor(Desc) {
+        if (this.Type(Desc) !== 'Object') {
+            return false;
+        }
+        const allowed = {
+            '[[Configurable]]': true,
+            '[[Enumerable]]': true,
+            '[[Get]]': true,
+            '[[Set]]': true,
+            '[[Value]]': true,
+            '[[Writable]]': true,
+        };
+        // jscs:disable
+		for (var key in Desc) { // eslint-disable-line
+            if (has(Desc, key) && !allowed[key]) {
+                return false;
+            }
+        }
+        // jscs:enable
+        const isData = has(Desc, '[[Value]]');
+        const IsAccessor = has(Desc, '[[Get]]') || has(Desc, '[[Set]]');
+        if (isData && IsAccessor) {
+            throw new TypeError(
+                'Property Descriptors may not be both accessor and data descriptors'
+            );
+        }
+        return true;
+    },
+
+    // http://ecma-international.org/ecma-262/5.1/#sec-8.10.1
+    IsAccessorDescriptor: function IsAccessorDescriptor(Desc) {
+        if (typeof Desc === 'undefined') {
+            return false;
+        }
+
+        if (!this.IsPropertyDescriptor(Desc)) {
+            throw new TypeError('Desc must be a Property Descriptor');
+        }
+
+        if (!has(Desc, '[[Get]]') && !has(Desc, '[[Set]]')) {
+            return false;
+        }
+
+        return true;
+    },
+
+    // http://ecma-international.org/ecma-262/5.1/#sec-8.10.2
+    IsDataDescriptor: function IsDataDescriptor(Desc) {
+        if (typeof Desc === 'undefined') {
+            return false;
+        }
+
+        if (!this.IsPropertyDescriptor(Desc)) {
+            throw new TypeError('Desc must be a Property Descriptor');
+        }
+
+        if (!has(Desc, '[[Value]]') && !has(Desc, '[[Writable]]')) {
+            return false;
+        }
+
+        return true;
+    },
+
+    // http://ecma-international.org/ecma-262/5.1/#sec-8.10.3
+    IsGenericDescriptor: function IsGenericDescriptor(Desc) {
+        if (typeof Desc === 'undefined') {
+            return false;
+        }
+
+        if (!this.IsPropertyDescriptor(Desc)) {
+            throw new TypeError('Desc must be a Property Descriptor');
+        }
+
+        if (!this.IsAccessorDescriptor(Desc) && !this.IsDataDescriptor(Desc)) {
+            return true;
+        }
+
+        return false;
+    },
+
+    // http://ecma-international.org/ecma-262/5.1/#sec-8.10.4
+    FromPropertyDescriptor: function FromPropertyDescriptor(Desc) {
+        if (typeof Desc === 'undefined') {
+            return Desc;
+        }
+
+        if (!this.IsPropertyDescriptor(Desc)) {
+            throw new TypeError('Desc must be a Property Descriptor');
+        }
+
+        if (this.IsDataDescriptor(Desc)) {
+            return {
+                value: Desc['[[Value]]'],
+                writable: !!Desc['[[Writable]]'],
+                enumerable: !!Desc['[[Enumerable]]'],
+                configurable: !!Desc['[[Configurable]]'],
+            };
+        } else if (this.IsAccessorDescriptor(Desc)) {
+            return {
+                get: Desc['[[Get]]'],
+                set: Desc['[[Set]]'],
+                enumerable: !!Desc['[[Enumerable]]'],
+                configurable: !!Desc['[[Configurable]]'],
+            };
+        } else {
+            throw new TypeError(
+                'FromPropertyDescriptor must be called with a fully populated Property Descriptor'
+            );
+        }
+    },
+
+    // http://ecma-international.org/ecma-262/5.1/#sec-8.10.5
+    ToPropertyDescriptor: function ToPropertyDescriptor(Obj) {
+        if (this.Type(Obj) !== 'Object') {
+            throw new TypeError('ToPropertyDescriptor requires an object');
+        }
+
+        const desc = {};
+        if (has(Obj, 'enumerable')) {
+            desc['[[Enumerable]]'] = this.ToBoolean(Obj.enumerable);
+        }
+        if (has(Obj, 'configurable')) {
+            desc['[[Configurable]]'] = this.ToBoolean(Obj.configurable);
+        }
+        if (has(Obj, 'value')) {
+            desc['[[Value]]'] = Obj.value;
+        }
+        if (has(Obj, 'writable')) {
+            desc['[[Writable]]'] = this.ToBoolean(Obj.writable);
+        }
+        if (has(Obj, 'get')) {
+            const getter = Obj.get;
+            if (typeof getter !== 'undefined' && !this.IsCallable(getter)) {
+                throw new TypeError('getter must be a function');
+            }
+            desc['[[Get]]'] = getter;
+        }
+        if (has(Obj, 'set')) {
+            const setter = Obj.set;
+            if (typeof setter !== 'undefined' && !this.IsCallable(setter)) {
+                throw new TypeError('setter must be a function');
+            }
+            desc['[[Set]]'] = setter;
+        }
+
+        if (
+            (has(desc, '[[Get]]') || has(desc, '[[Set]]')) &&
+            (has(desc, '[[Value]]') || has(desc, '[[Writable]]'))
+        ) {
+            throw new TypeError(
+                'Invalid property descriptor. Cannot both specify accessors and a value or writable attribute'
+            );
+        }
+        return desc;
+    },
+};
+
+module.exports = ES5;

--- a/test/mock/identical-implementation/node_modules/es-abstract/es6.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/es6.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./es2015');

--- a/test/mock/identical-implementation/node_modules/es-abstract/es7.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/es7.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./es2016');

--- a/test/mock/identical-implementation/node_modules/es-abstract/helpers/assign.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/helpers/assign.js
@@ -1,0 +1,12 @@
+const has = Object.prototype.hasOwnProperty;
+module.exports = function assign(target, source) {
+    if (Object.assign) {
+        return Object.assign(target, source);
+    }
+    for (const key in source) {
+        if (has.call(source, key)) {
+            target[key] = source[key];
+        }
+    }
+    return target;
+};

--- a/test/mock/identical-implementation/node_modules/es-abstract/helpers/isFinite.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/helpers/isFinite.js
@@ -1,0 +1,16 @@
+const $isNaN =
+    Number.isNaN ||
+    function(a) {
+        return a !== a;
+    };
+
+module.exports =
+    Number.isFinite ||
+    function(x) {
+        return (
+            typeof x === 'number' &&
+            !$isNaN(x) &&
+            x !== Infinity &&
+            x !== -Infinity
+        );
+    };

--- a/test/mock/identical-implementation/node_modules/es-abstract/helpers/isNaN.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/helpers/isNaN.js
@@ -1,0 +1,5 @@
+module.exports =
+    Number.isNaN ||
+    function isNaN(a) {
+        return a !== a;
+    };

--- a/test/mock/identical-implementation/node_modules/es-abstract/helpers/isPrimitive.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/helpers/isPrimitive.js
@@ -1,0 +1,6 @@
+module.exports = function isPrimitive(value) {
+    return (
+        value === null ||
+        (typeof value !== 'function' && typeof value !== 'object')
+    );
+};

--- a/test/mock/identical-implementation/node_modules/es-abstract/helpers/mod.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/helpers/mod.js
@@ -1,0 +1,4 @@
+module.exports = function mod(number, modulo) {
+    const remain = number % modulo;
+    return Math.floor(remain >= 0 ? remain : remain + modulo);
+};

--- a/test/mock/identical-implementation/node_modules/es-abstract/helpers/sign.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/helpers/sign.js
@@ -1,0 +1,3 @@
+module.exports = function sign(number) {
+    return number >= 0 ? 1 : -1;
+};

--- a/test/mock/identical-implementation/node_modules/es-abstract/index.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/index.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const assign = require('./helpers/assign');
+
+const ES5 = require('./es5');
+const ES2015 = require('./es2015');
+const ES2016 = require('./es2016');
+const ES2017 = require('./es2017');
+
+const ES = {
+    ES5,
+    ES6: ES2015,
+    ES2015,
+    ES7: ES2016,
+    ES2016,
+    ES2017,
+};
+assign(ES, ES5);
+delete ES.CheckObjectCoercible; // renamed in ES6 to RequireObjectCoercible
+assign(ES, ES2015);
+
+module.exports = ES;

--- a/test/mock/identical-implementation/node_modules/es-abstract/operations/2015.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/operations/2015.js
@@ -1,0 +1,119 @@
+'use strict';
+
+module.exports = {
+    IsPropertyDescriptor:
+        'http://ecma-international.org/ecma-262/6.0/#sec-property-descriptor-specification-type',
+    IsAccessorDescriptor:
+        'http://ecma-international.org/ecma-262/6.0/#sec-isaccessordescriptor',
+    IsDataDescriptor:
+        'http://ecma-international.org/ecma-262/6.0/#sec-isdatadescriptor',
+    IsGenericDescriptor:
+        'http://ecma-international.org/ecma-262/6.0/#sec-isgenericdescriptor',
+    FromPropertyDescriptor:
+        'http://ecma-international.org/ecma-262/6.0/#sec-frompropertydescriptor',
+    ToPropertyDescriptor:
+        'http://ecma-international.org/ecma-262/6.0/#sec-topropertydescriptor',
+    CompletePropertyDescriptor:
+        'http://ecma-international.org/ecma-262/6.0/#sec-completepropertydescriptor',
+    ToPrimitive: 'http://ecma-international.org/ecma-262/6.0/#sec-toprimitive',
+    ToBoolean: 'http://ecma-international.org/ecma-262/6.0/#sec-toboolean',
+    ToNumber: 'http://ecma-international.org/ecma-262/6.0/#sec-tonumber',
+    ToInteger: 'http://ecma-international.org/ecma-262/6.0/#sec-tointeger',
+    ToInt32: 'http://ecma-international.org/ecma-262/6.0/#sec-toint32',
+    ToUint32: 'http://ecma-international.org/ecma-262/6.0/#sec-touint32',
+    ToInt16: 'http://ecma-international.org/ecma-262/6.0/#sec-toint16',
+    ToUint16: 'http://ecma-international.org/ecma-262/6.0/#sec-touint16',
+    ToInt8: 'http://ecma-international.org/ecma-262/6.0/#sec-toint8',
+    ToUint8: 'http://ecma-international.org/ecma-262/6.0/#sec-touint8',
+    ToUint8Clamp:
+        'http://ecma-international.org/ecma-262/6.0/#sec-touint8clamp',
+    ToString: 'http://ecma-international.org/ecma-262/6.0/#sec-tostring',
+    ToObject: 'http://ecma-international.org/ecma-262/6.0/#sec-toobject',
+    ToPropertyKey:
+        'http://ecma-international.org/ecma-262/6.0/#sec-topropertykey',
+    ToLength: 'http://ecma-international.org/ecma-262/6.0/#sec-tolength',
+    CanonicalNumericIndexString:
+        'http://ecma-international.org/ecma-262/6.0/#sec-canonicalnumericindexstring',
+    RequireObjectCoercible:
+        'http://ecma-international.org/ecma-262/6.0/#sec-requireobjectcoercible',
+    IsArray: 'http://ecma-international.org/ecma-262/6.0/#sec-isarray',
+    IsCallable: 'http://ecma-international.org/ecma-262/6.0/#sec-iscallable',
+    IsConstructor:
+        'http://ecma-international.org/ecma-262/6.0/#sec-isconstructor',
+    IsExtensible:
+        'http://ecma-international.org/ecma-262/6.0/#sec-isextensible-o',
+    IsInteger: 'http://ecma-international.org/ecma-262/6.0/#sec-isinteger',
+    IsPropertyKey:
+        'http://ecma-international.org/ecma-262/6.0/#sec-ispropertykey',
+    IsRegExp: 'http://ecma-international.org/ecma-262/6.0/#sec-isregexp',
+    SameValue: 'http://ecma-international.org/ecma-262/6.0/#sec-samevalue',
+    SameValueZero:
+        'http://ecma-international.org/ecma-262/6.0/#sec-samevaluezero',
+    Get: 'http://ecma-international.org/ecma-262/6.0/#sec-get-o-p',
+    GetV: 'http://ecma-international.org/ecma-262/6.0/#sec-getv',
+    Set: 'http://ecma-international.org/ecma-262/6.0/#sec-set-o-p-v-throw',
+    CreateDataProperty:
+        'http://ecma-international.org/ecma-262/6.0/#sec-createdataproperty',
+    CreateMethodProperty:
+        'http://ecma-international.org/ecma-262/6.0/#sec-createmethodproperty',
+    CreateDataPropertyOrThrow:
+        'http://ecma-international.org/ecma-262/6.0/#sec-createdatapropertyorthrow',
+    DefinePropertyOrThrow:
+        'http://ecma-international.org/ecma-262/6.0/#sec-definepropertyorthrow',
+    DeletePropertyOrThrow:
+        'http://ecma-international.org/ecma-262/6.0/#sec-deletepropertyorthrow',
+    GetMethod: 'http://ecma-international.org/ecma-262/6.0/#sec-getmethod',
+    HasProperty: 'http://ecma-international.org/ecma-262/6.0/#sec-hasproperty',
+    HasOwnProperty:
+        'http://ecma-international.org/ecma-262/6.0/#sec-hasownproperty',
+    Call: 'http://ecma-international.org/ecma-262/6.0/#sec-call',
+    Construct: 'http://ecma-international.org/ecma-262/6.0/#sec-construct',
+    SetIntegrityLevel:
+        'http://ecma-international.org/ecma-262/6.0/#sec-setintegritylevel',
+    TestIntegrityLevel:
+        'http://ecma-international.org/ecma-262/6.0/#sec-testintegritylevel',
+    CreateArrayFromList:
+        'http://ecma-international.org/ecma-262/6.0/#sec-createarrayfromlist',
+    CreateListFromArrayLike:
+        'http://ecma-international.org/ecma-262/6.0/#sec-createlistfromarraylike',
+    Invoke: 'http://ecma-international.org/ecma-262/6.0/#sec-invoke',
+    OrdinaryHasInstance:
+        'http://ecma-international.org/ecma-262/6.0/#sec-ordinaryhasinstance',
+    SpeciesConstructor:
+        'http://ecma-international.org/ecma-262/6.0/#sec-speciesconstructor',
+    EnumerableOwnNames:
+        'http://ecma-international.org/ecma-262/6.0/#sec-enumerableownnames',
+    GetIterator: 'http://ecma-international.org/ecma-262/6.0/#sec-getiterator',
+    IteratorNext:
+        'http://ecma-international.org/ecma-262/6.0/#sec-iteratornext',
+    IteratorComplete:
+        'http://ecma-international.org/ecma-262/6.0/#sec-iteratorcomplete',
+    IteratorValue:
+        'http://ecma-international.org/ecma-262/6.0/#sec-iteratorvalue',
+    IteratorStep:
+        'http://ecma-international.org/ecma-262/6.0/#sec-iteratorstep',
+    IteratorClose:
+        'http://ecma-international.org/ecma-262/6.0/#sec-iteratorclose',
+    CreateIterResultObject:
+        'http://ecma-international.org/ecma-262/6.0/#sec-createiterresultobject',
+    CreateListIterator:
+        'http://ecma-international.org/ecma-262/6.0/#sec-createlistiterator',
+    Type:
+        'http://ecma-international.org/ecma-262/6.0/#sec-ecmascript-language-types',
+    thisNumberValue:
+        'http://ecma-international.org/ecma-262/6.0/#sec-properties-of-the-number-prototype-object',
+    thisTimeValue:
+        'http://ecma-international.org/ecma-262/6.0/#sec-properties-of-the-date-prototype-object',
+    thisStringValue:
+        'http://ecma-international.org/ecma-262/6.0/#sec-properties-of-the-string-prototype-object',
+    RegExpExec: 'http://ecma-international.org/ecma-262/6.0/#sec-regexpexec',
+    RegExpBuiltinExec:
+        'http://ecma-international.org/ecma-262/6.0/#sec-regexpbuiltinexec',
+    IsConcatSpreadable:
+        'http://ecma-international.org/ecma-262/6.0/#sec-isconcatspreadable',
+    IsPromise: 'http://ecma-international.org/ecma-262/6.0/#sec-ispromise',
+    ArraySpeciesCreate:
+        'http://ecma-international.org/ecma-262/6.0/#sec-arrayspeciescreate',
+    AdvanceStringIndex:
+        'http://ecma-international.org/ecma-262/6.0/#sec-advancestringindex',
+};

--- a/test/mock/identical-implementation/node_modules/es-abstract/operations/2016.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/operations/2016.js
@@ -1,0 +1,121 @@
+'use strict';
+
+module.exports = {
+    IsPropertyDescriptor:
+        'http://ecma-international.org/ecma-262/7.0/#sec-property-descriptor-specification-type',
+    IsAccessorDescriptor:
+        'http://ecma-international.org/ecma-262/7.0/#sec-isaccessordescriptor',
+    IsDataDescriptor:
+        'http://ecma-international.org/ecma-262/7.0/#sec-isdatadescriptor',
+    IsGenericDescriptor:
+        'http://ecma-international.org/ecma-262/7.0/#sec-isgenericdescriptor',
+    FromPropertyDescriptor:
+        'http://ecma-international.org/ecma-262/7.0/#sec-frompropertydescriptor',
+    ToPropertyDescriptor:
+        'http://ecma-international.org/ecma-262/7.0/#sec-topropertydescriptor',
+    CompletePropertyDescriptor:
+        'http://ecma-international.org/ecma-262/7.0/#sec-completepropertydescriptor',
+    ToPrimitive: 'http://ecma-international.org/ecma-262/7.0/#sec-toprimitive',
+    ToBoolean: 'http://ecma-international.org/ecma-262/7.0/#sec-toboolean',
+    ToNumber: 'http://ecma-international.org/ecma-262/7.0/#sec-tonumber',
+    ToInteger: 'http://ecma-international.org/ecma-262/7.0/#sec-tointeger',
+    ToInt32: 'http://ecma-international.org/ecma-262/7.0/#sec-toint32',
+    ToUint32: 'http://ecma-international.org/ecma-262/7.0/#sec-touint32',
+    ToInt16: 'http://ecma-international.org/ecma-262/7.0/#sec-toint16',
+    ToUint16: 'http://ecma-international.org/ecma-262/7.0/#sec-touint16',
+    ToInt8: 'http://ecma-international.org/ecma-262/7.0/#sec-toint8',
+    ToUint8: 'http://ecma-international.org/ecma-262/7.0/#sec-touint8',
+    ToUint8Clamp:
+        'http://ecma-international.org/ecma-262/7.0/#sec-touint8clamp',
+    ToString: 'http://ecma-international.org/ecma-262/7.0/#sec-tostring',
+    ToObject: 'http://ecma-international.org/ecma-262/7.0/#sec-toobject',
+    ToPropertyKey:
+        'http://ecma-international.org/ecma-262/7.0/#sec-topropertykey',
+    ToLength: 'http://ecma-international.org/ecma-262/7.0/#sec-tolength',
+    CanonicalNumericIndexString:
+        'http://ecma-international.org/ecma-262/7.0/#sec-canonicalnumericindexstring',
+    RequireObjectCoercible:
+        'http://ecma-international.org/ecma-262/7.0/#sec-requireobjectcoercible',
+    IsArray: 'http://ecma-international.org/ecma-262/7.0/#sec-isarray',
+    IsCallable: 'http://ecma-international.org/ecma-262/7.0/#sec-iscallable',
+    IsConstructor:
+        'http://ecma-international.org/ecma-262/7.0/#sec-isconstructor',
+    IsExtensible:
+        'http://ecma-international.org/ecma-262/7.0/#sec-isextensible-o',
+    IsInteger: 'http://ecma-international.org/ecma-262/7.0/#sec-isinteger',
+    IsPropertyKey:
+        'http://ecma-international.org/ecma-262/7.0/#sec-ispropertykey',
+    IsRegExp: 'http://ecma-international.org/ecma-262/7.0/#sec-isregexp',
+    SameValue: 'http://ecma-international.org/ecma-262/7.0/#sec-samevalue',
+    SameValueZero:
+        'http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero',
+    SameValueNonNumber:
+        'http://ecma-international.org/ecma-262/7.0/#sec-samevaluenonnumber',
+    Get: 'http://ecma-international.org/ecma-262/7.0/#sec-get-o-p',
+    GetV: 'http://ecma-international.org/ecma-262/7.0/#sec-getv',
+    Set: 'http://ecma-international.org/ecma-262/7.0/#sec-set-o-p-v-throw',
+    CreateDataProperty:
+        'http://ecma-international.org/ecma-262/7.0/#sec-createdataproperty',
+    CreateMethodProperty:
+        'http://ecma-international.org/ecma-262/7.0/#sec-createmethodproperty',
+    CreateDataPropertyOrThrow:
+        'http://ecma-international.org/ecma-262/7.0/#sec-createdatapropertyorthrow',
+    DefinePropertyOrThrow:
+        'http://ecma-international.org/ecma-262/7.0/#sec-definepropertyorthrow',
+    DeletePropertyOrThrow:
+        'http://ecma-international.org/ecma-262/7.0/#sec-deletepropertyorthrow',
+    GetMethod: 'http://ecma-international.org/ecma-262/7.0/#sec-getmethod',
+    HasProperty: 'http://ecma-international.org/ecma-262/7.0/#sec-hasproperty',
+    HasOwnProperty:
+        'http://ecma-international.org/ecma-262/7.0/#sec-hasownproperty',
+    Call: 'http://ecma-international.org/ecma-262/7.0/#sec-call',
+    Construct: 'http://ecma-international.org/ecma-262/7.0/#sec-construct',
+    SetIntegrityLevel:
+        'http://ecma-international.org/ecma-262/7.0/#sec-setintegritylevel',
+    TestIntegrityLevel:
+        'http://ecma-international.org/ecma-262/7.0/#sec-testintegritylevel',
+    CreateArrayFromList:
+        'http://ecma-international.org/ecma-262/7.0/#sec-createarrayfromlist',
+    CreateListFromArrayLike:
+        'http://ecma-international.org/ecma-262/7.0/#sec-createlistfromarraylike',
+    Invoke: 'http://ecma-international.org/ecma-262/7.0/#sec-invoke',
+    OrdinaryHasInstance:
+        'http://ecma-international.org/ecma-262/7.0/#sec-ordinaryhasinstance',
+    SpeciesConstructor:
+        'http://ecma-international.org/ecma-262/7.0/#sec-speciesconstructor',
+    EnumerableOwnNames:
+        'http://ecma-international.org/ecma-262/7.0/#sec-enumerableownnames',
+    GetIterator: 'http://ecma-international.org/ecma-262/7.0/#sec-getiterator',
+    IteratorNext:
+        'http://ecma-international.org/ecma-262/7.0/#sec-iteratornext',
+    IteratorComplete:
+        'http://ecma-international.org/ecma-262/7.0/#sec-iteratorcomplete',
+    IteratorValue:
+        'http://ecma-international.org/ecma-262/7.0/#sec-iteratorvalue',
+    IteratorStep:
+        'http://ecma-international.org/ecma-262/7.0/#sec-iteratorstep',
+    IteratorClose:
+        'http://ecma-international.org/ecma-262/7.0/#sec-iteratorclose',
+    CreateIterResultObject:
+        'http://ecma-international.org/ecma-262/7.0/#sec-createiterresultobject',
+    CreateListIterator:
+        'http://ecma-international.org/ecma-262/7.0/#sec-createlistiterator',
+    Type:
+        'http://ecma-international.org/ecma-262/7.0/#sec-ecmascript-language-types',
+    thisNumberValue:
+        'http://ecma-international.org/ecma-262/7.0/#sec-properties-of-the-number-prototype-object',
+    thisTimeValue:
+        'http://ecma-international.org/ecma-262/7.0/#sec-properties-of-the-date-prototype-object',
+    thisStringValue:
+        'http://ecma-international.org/ecma-262/7.0/#sec-properties-of-the-string-prototype-object',
+    RegExpExec: 'http://ecma-international.org/ecma-262/7.0/#sec-regexpexec',
+    RegExpBuiltinExec:
+        'http://ecma-international.org/ecma-262/7.0/#sec-regexpbuiltinexec',
+    IsConcatSpreadable:
+        'http://ecma-international.org/ecma-262/7.0/#sec-isconcatspreadable',
+    IsPromise: 'http://ecma-international.org/ecma-262/7.0/#sec-ispromise',
+    ArraySpeciesCreate:
+        'http://ecma-international.org/ecma-262/7.0/#sec-arrayspeciescreate',
+    AdvanceStringIndex:
+        'http://ecma-international.org/ecma-262/6.0/#sec-advancestringindex',
+};

--- a/test/mock/identical-implementation/node_modules/es-abstract/operations/2017.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/operations/2017.js
@@ -1,0 +1,122 @@
+'use strict';
+
+module.exports = {
+    IsPropertyDescriptor:
+        'http://ecma-international.org/ecma-262/8.0/#sec-property-descriptor-specification-type',
+    IsAccessorDescriptor:
+        'http://ecma-international.org/ecma-262/8.0/#sec-isaccessordescriptor',
+    IsDataDescriptor:
+        'http://ecma-international.org/ecma-262/8.0/#sec-isdatadescriptor',
+    IsGenericDescriptor:
+        'http://ecma-international.org/ecma-262/8.0/#sec-isgenericdescriptor',
+    FromPropertyDescriptor:
+        'http://ecma-international.org/ecma-262/8.0/#sec-frompropertydescriptor',
+    ToPropertyDescriptor:
+        'http://ecma-international.org/ecma-262/8.0/#sec-topropertydescriptor',
+    CompletePropertyDescriptor:
+        'http://ecma-international.org/ecma-262/8.0/#sec-completepropertydescriptor',
+    ToPrimitive: 'http://ecma-international.org/ecma-262/8.0/#sec-toprimitive',
+    ToBoolean: 'http://ecma-international.org/ecma-262/8.0/#sec-toboolean',
+    ToNumber: 'http://ecma-international.org/ecma-262/8.0/#sec-tonumber',
+    ToInteger: 'http://ecma-international.org/ecma-262/8.0/#sec-tointeger',
+    ToInt32: 'http://ecma-international.org/ecma-262/8.0/#sec-toint32',
+    ToUint32: 'http://ecma-international.org/ecma-262/8.0/#sec-touint32',
+    ToInt16: 'http://ecma-international.org/ecma-262/8.0/#sec-toint16',
+    ToUint16: 'http://ecma-international.org/ecma-262/8.0/#sec-touint16',
+    ToInt8: 'http://ecma-international.org/ecma-262/8.0/#sec-toint8',
+    ToUint8: 'http://ecma-international.org/ecma-262/8.0/#sec-touint8',
+    ToUint8Clamp:
+        'http://ecma-international.org/ecma-262/8.0/#sec-touint8clamp',
+    ToString: 'http://ecma-international.org/ecma-262/8.0/#sec-tostring',
+    ToObject: 'http://ecma-international.org/ecma-262/8.0/#sec-toobject',
+    ToPropertyKey:
+        'http://ecma-international.org/ecma-262/8.0/#sec-topropertykey',
+    ToLength: 'http://ecma-international.org/ecma-262/8.0/#sec-tolength',
+    CanonicalNumericIndexString:
+        'http://ecma-international.org/ecma-262/8.0/#sec-canonicalnumericindexstring',
+    ToIndex: 'http://ecma-international.org/ecma-262/8.0/#sec-toindex',
+    RequireObjectCoercible:
+        'http://ecma-international.org/ecma-262/8.0/#sec-requireobjectcoercible',
+    IsArray: 'http://ecma-international.org/ecma-262/8.0/#sec-isarray',
+    IsCallable: 'http://ecma-international.org/ecma-262/8.0/#sec-iscallable',
+    IsConstructor:
+        'http://ecma-international.org/ecma-262/8.0/#sec-isconstructor',
+    IsExtensible:
+        'http://ecma-international.org/ecma-262/8.0/#sec-isextensible-o',
+    IsInteger: 'http://ecma-international.org/ecma-262/8.0/#sec-isinteger',
+    IsPropertyKey:
+        'http://ecma-international.org/ecma-262/8.0/#sec-ispropertykey',
+    IsRegExp: 'http://ecma-international.org/ecma-262/8.0/#sec-isregexp',
+    SameValue: 'http://ecma-international.org/ecma-262/8.0/#sec-samevalue',
+    SameValueZero:
+        'http://ecma-international.org/ecma-262/8.0/#sec-samevaluezero',
+    SameValueNonNumber:
+        'http://ecma-international.org/ecma-262/8.0/#sec-samevaluenonnumber',
+    Get: 'http://ecma-international.org/ecma-262/8.0/#sec-get-o-p',
+    GetV: 'http://ecma-international.org/ecma-262/8.0/#sec-getv',
+    Set: 'http://ecma-international.org/ecma-262/8.0/#sec-set-o-p-v-throw',
+    CreateDataProperty:
+        'http://ecma-international.org/ecma-262/8.0/#sec-createdataproperty',
+    CreateMethodProperty:
+        'http://ecma-international.org/ecma-262/8.0/#sec-createmethodproperty',
+    CreateDataPropertyOrThrow:
+        'http://ecma-international.org/ecma-262/8.0/#sec-createdatapropertyorthrow',
+    DefinePropertyOrThrow:
+        'http://ecma-international.org/ecma-262/8.0/#sec-definepropertyorthrow',
+    DeletePropertyOrThrow:
+        'http://ecma-international.org/ecma-262/8.0/#sec-deletepropertyorthrow',
+    GetMethod: 'http://ecma-international.org/ecma-262/8.0/#sec-getmethod',
+    HasProperty: 'http://ecma-international.org/ecma-262/8.0/#sec-hasproperty',
+    HasOwnProperty:
+        'http://ecma-international.org/ecma-262/8.0/#sec-hasownproperty',
+    Call: 'http://ecma-international.org/ecma-262/8.0/#sec-call',
+    Construct: 'http://ecma-international.org/ecma-262/8.0/#sec-construct',
+    SetIntegrityLevel:
+        'http://ecma-international.org/ecma-262/8.0/#sec-setintegritylevel',
+    TestIntegrityLevel:
+        'http://ecma-international.org/ecma-262/8.0/#sec-testintegritylevel',
+    CreateArrayFromList:
+        'http://ecma-international.org/ecma-262/8.0/#sec-createarrayfromlist',
+    CreateListFromArrayLike:
+        'http://ecma-international.org/ecma-262/8.0/#sec-createlistfromarraylike',
+    Invoke: 'http://ecma-international.org/ecma-262/8.0/#sec-invoke',
+    OrdinaryHasInstance:
+        'http://ecma-international.org/ecma-262/8.0/#sec-ordinaryhasinstance',
+    SpeciesConstructor:
+        'http://ecma-international.org/ecma-262/8.0/#sec-speciesconstructor',
+    EnumerableOwnProperties:
+        'http://ecma-international.org/ecma-262/8.0/#sec-enumerableownproperties',
+    GetIterator: 'http://ecma-international.org/ecma-262/8.0/#sec-getiterator',
+    IteratorNext:
+        'http://ecma-international.org/ecma-262/8.0/#sec-iteratornext',
+    IteratorComplete:
+        'http://ecma-international.org/ecma-262/8.0/#sec-iteratorcomplete',
+    IteratorValue:
+        'http://ecma-international.org/ecma-262/8.0/#sec-iteratorvalue',
+    IteratorStep:
+        'http://ecma-international.org/ecma-262/8.0/#sec-iteratorstep',
+    IteratorClose:
+        'http://ecma-international.org/ecma-262/8.0/#sec-iteratorclose',
+    CreateIterResultObject:
+        'http://ecma-international.org/ecma-262/8.0/#sec-createiterresultobject',
+    CreateListIterator:
+        'http://ecma-international.org/ecma-262/8.0/#sec-createlistiterator',
+    Type:
+        'http://ecma-international.org/ecma-262/8.0/#sec-ecmascript-language-types',
+    thisNumberValue:
+        'http://ecma-international.org/ecma-262/8.0/#sec-properties-of-the-number-prototype-object',
+    thisTimeValue:
+        'http://ecma-international.org/ecma-262/8.0/#sec-properties-of-the-date-prototype-object',
+    thisStringValue:
+        'http://ecma-international.org/ecma-262/8.0/#sec-properties-of-the-string-prototype-object',
+    RegExpExec: 'http://ecma-international.org/ecma-262/8.0/#sec-regexpexec',
+    RegExpBuiltinExec:
+        'http://ecma-international.org/ecma-262/8.0/#sec-regexpbuiltinexec',
+    IsConcatSpreadable:
+        'http://ecma-international.org/ecma-262/8.0/#sec-isconcatspreadable',
+    IsPromise: 'http://ecma-international.org/ecma-262/8.0/#sec-ispromise',
+    ArraySpeciesCreate:
+        'http://ecma-international.org/ecma-262/8.0/#sec-arrayspeciescreate',
+    AdvanceStringIndex:
+        'http://ecma-international.org/ecma-262/6.0/#sec-advancestringindex',
+};

--- a/test/mock/identical-implementation/node_modules/es-abstract/operations/es5.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/operations/es5.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+    IsPropertyDescriptor:
+        'http://ecma-international.org/ecma-262/5.1/#sec-8.10',
+    IsAccessorDescriptor:
+        'http://ecma-international.org/ecma-262/5.1/#sec-8.10.1',
+    IsDataDescriptor: 'http://ecma-international.org/ecma-262/5.1/#sec-8.10.2',
+    IsGenericDescriptor:
+        'http://ecma-international.org/ecma-262/5.1/#sec-8.10.3',
+    FromPropertyDescriptor:
+        'http://ecma-international.org/ecma-262/5.1/#sec-8.10.4',
+    ToPropertyDescriptor:
+        'http://ecma-international.org/ecma-262/5.1/#sec-8.10.5',
+};

--- a/test/mock/identical-implementation/node_modules/es-abstract/package.json
+++ b/test/mock/identical-implementation/node_modules/es-abstract/package.json
@@ -1,0 +1,121 @@
+{
+  "_from": "es-abstract@^1.6.1",
+  "_id": "es-abstract@1.10.0",
+  "_inBundle": false,
+  "_integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+  "_location": "/es-abstract",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "range",
+    "registry": true,
+    "raw": "es-abstract@^1.6.1",
+    "name": "es-abstract",
+    "escapedName": "es-abstract",
+    "rawSpec": "^1.6.1",
+    "saveSpec": null,
+    "fetchSpec": "^1.6.1"
+  },
+  "_requiredBy": [
+    "/object.entries",
+    "/object.values"
+  ],
+  "_resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
+  "_shasum": "1ecb36c197842a00d8ee4c2dfd8646bb97d60864",
+  "_spec": "es-abstract@^1.6.1",
+  "_where": "/Users/ricwalke/src/asset-pipe/asset-pipe-js-writer/test/mock/identical-implementation/node_modules/object.entries",
+  "author": {
+    "name": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "url": "http://ljharb.codes"
+  },
+  "bugs": {
+    "url": "https://github.com/ljharb/es-abstract/issues"
+  },
+  "bundleDependencies": false,
+  "contributors": [
+    {
+      "name": "Jordan Harband",
+      "email": "ljharb@gmail.com",
+      "url": "http://ljharb.codes"
+    }
+  ],
+  "dependencies": {
+    "es-to-primitive": "^1.1.1",
+    "function-bind": "^1.1.1",
+    "has": "^1.0.1",
+    "is-callable": "^1.1.3",
+    "is-regex": "^1.0.4"
+  },
+  "deprecated": false,
+  "description": "ECMAScript spec abstract operations.",
+  "devDependencies": {
+    "@ljharb/eslint-config": "^12.2.1",
+    "editorconfig-tools": "^0.1.1",
+    "eslint": "^4.11.0",
+    "foreach": "^2.0.5",
+    "jscs": "^3.0.7",
+    "nsp": "^3.1.0",
+    "nyc": "^10.3.2",
+    "object-is": "^1.0.1",
+    "object.assign": "^4.0.4",
+    "replace": "^0.3.0",
+    "safe-publish-latest": "^1.1.1",
+    "semver": "^5.4.1",
+    "tape": "^4.8.0"
+  },
+  "engines": {
+    "node": ">= 0.4"
+  },
+  "homepage": "https://github.com/ljharb/es-abstract#readme",
+  "keywords": [
+    "ECMAScript",
+    "ES",
+    "abstract",
+    "operation",
+    "abstract operation",
+    "JavaScript",
+    "ES5",
+    "ES6",
+    "ES7"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "name": "es-abstract",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ljharb/es-abstract.git"
+  },
+  "scripts": {
+    "coverage": "nyc npm run --silent tests-only >/dev/null 2>&1",
+    "eccheck": "editorconfig-tools check *.js **/*.js > /dev/null",
+    "eslint": "eslint test/*.js *.js",
+    "jscs": "jscs test/*.js *.js",
+    "lint": "npm run --silent jscs && npm run --silent eslint",
+    "postcoverage": "nyc report",
+    "posttest": "npm run --silent security",
+    "prepublish": "safe-publish-latest",
+    "pretest": "npm run --silent lint",
+    "security": "nsp check",
+    "test": "npm run tests-only",
+    "tests-only": "node test"
+  },
+  "testling": {
+    "files": "test/index.js",
+    "browsers": [
+      "iexplore/6.0..latest",
+      "firefox/3.0..6.0",
+      "firefox/15.0..latest",
+      "firefox/nightly",
+      "chrome/4.0..10.0",
+      "chrome/20.0..latest",
+      "chrome/canary",
+      "opera/10.0..latest",
+      "opera/next",
+      "safari/4.0..latest",
+      "ipad/6.0..latest",
+      "iphone/6.0..latest",
+      "android-browser/4.2"
+    ]
+  },
+  "version": "1.10.0"
+}

--- a/test/mock/identical-implementation/node_modules/es-abstract/test/.eslintrc
+++ b/test/mock/identical-implementation/node_modules/es-abstract/test/.eslintrc
@@ -1,0 +1,11 @@
+{
+	"rules": {
+		"id-length": 0,
+		"max-lines": 0,
+		"max-statements-per-line": [2, { "max": 3 }],
+		"max-nested-callbacks": [2, 3],
+		"max-statements": 0,
+		"no-implicit-coercion": [1],
+		"no-invalid-this": [1]
+	}
+}

--- a/test/mock/identical-implementation/node_modules/es-abstract/test/diffOps.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/test/diffOps.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const keys = require('object-keys');
+const forEach = require('foreach');
+
+module.exports = function diffOperations(actual, expected) {
+    const actualKeys = keys(actual);
+    const expectedKeys = keys(expected);
+
+    const extra = [];
+    const missing = [];
+    forEach(actualKeys, op => {
+        if (!(op in expected)) {
+            extra.push(op);
+        }
+    });
+    forEach(expectedKeys, op => {
+        if (!(op in actual)) {
+            missing.push(op);
+        }
+    });
+
+    return { missing, extra };
+};

--- a/test/mock/identical-implementation/node_modules/es-abstract/test/es2015.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/test/es2015.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const ES = require('../').ES2015;
+
+const ops = require('../operations/2015');
+
+// jscs:disable
+const expectedMissing = [
+    'CreateMethodProperty',
+    'DefinePropertyOrThrow',
+    'DeletePropertyOrThrow',
+    'Construct',
+    'SetIntegrityLevel',
+    'TestIntegrityLevel',
+    'CreateArrayFromList',
+    'CreateListFromArrayLike',
+    'OrdinaryHasInstance',
+    'EnumerableOwnNames',
+    'GetIterator',
+    'IteratorNext',
+    'IteratorComplete',
+    'IteratorValue',
+    'IteratorStep',
+    'IteratorClose',
+    'CreateListIterator',
+    'thisNumberValue',
+    'thisTimeValue',
+    'thisStringValue',
+    'RegExpBuiltinExec',
+    'IsPromise',
+];
+// jscs:enable
+
+require('./tests').es2015(ES, ops, expectedMissing);

--- a/test/mock/identical-implementation/node_modules/es-abstract/test/es2016.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/test/es2016.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const ES = require('../').ES2016;
+
+const ops = require('../operations/2016');
+
+// jscs:disable
+const expectedMissing = [
+    'CreateMethodProperty',
+    'DefinePropertyOrThrow',
+    'DeletePropertyOrThrow',
+    'Construct',
+    'SetIntegrityLevel',
+    'TestIntegrityLevel',
+    'CreateArrayFromList',
+    'CreateListFromArrayLike',
+    'OrdinaryHasInstance',
+    'EnumerableOwnNames',
+    'GetIterator',
+    'IteratorNext',
+    'IteratorComplete',
+    'IteratorValue',
+    'IteratorStep',
+    'IteratorClose',
+    'CreateListIterator',
+    'thisNumberValue',
+    'thisTimeValue',
+    'thisStringValue',
+    'RegExpBuiltinExec',
+    'IsPromise',
+];
+// jscs:enable
+
+require('./tests').es2016(ES, ops, expectedMissing);

--- a/test/mock/identical-implementation/node_modules/es-abstract/test/es2017.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/test/es2017.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const ES = require('../').ES2017;
+
+const ops = require('../operations/2017');
+
+// jscs:disable
+const expectedMissing = [
+    'CreateMethodProperty',
+    'DefinePropertyOrThrow',
+    'DeletePropertyOrThrow',
+    'Construct',
+    'SetIntegrityLevel',
+    'TestIntegrityLevel',
+    'CreateArrayFromList',
+    'CreateListFromArrayLike',
+    'OrdinaryHasInstance',
+    'EnumerableOwnProperties',
+    'GetIterator',
+    'IteratorNext',
+    'IteratorComplete',
+    'IteratorValue',
+    'IteratorStep',
+    'IteratorClose',
+    'CreateListIterator',
+    'thisNumberValue',
+    'thisTimeValue',
+    'thisStringValue',
+    'RegExpBuiltinExec',
+    'IsPromise',
+];
+// jscs:enable
+
+require('./tests').es2017(ES, ops, expectedMissing);

--- a/test/mock/identical-implementation/node_modules/es-abstract/test/es5.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/test/es5.js
@@ -1,0 +1,736 @@
+'use strict';
+
+const ES = require('../').ES5;
+const test = require('tape');
+
+const forEach = require('foreach');
+const is = require('object-is');
+
+const coercibleObject = {
+    valueOf() {
+        return '3';
+    },
+    toString() {
+        return 42;
+    },
+};
+const coercibleFnObject = {
+    valueOf() {
+        return function valueOfFn() {};
+    },
+    toString() {
+        return 42;
+    },
+};
+const valueOfOnlyObject = {
+    valueOf() {
+        return 4;
+    },
+    toString() {
+        return {};
+    },
+};
+const toStringOnlyObject = {
+    valueOf() {
+        return {};
+    },
+    toString() {
+        return 7;
+    },
+};
+const uncoercibleObject = {
+    valueOf() {
+        return {};
+    },
+    toString() {
+        return {};
+    },
+};
+const uncoercibleFnObject = {
+    valueOf() {
+        return function valueOfFn() {};
+    },
+    toString() {
+        return function toStrFn() {};
+    },
+};
+const objects = [{}, coercibleObject, toStringOnlyObject, valueOfOnlyObject];
+const numbers = [0, -0, Infinity, -Infinity, 42];
+const nonNullPrimitives = [true, false, 'foo', ''].concat(numbers);
+const primitives = [undefined, null].concat(nonNullPrimitives);
+
+test('ToPrimitive', t => {
+    t.test('primitives', st => {
+        const testPrimitive = function(primitive) {
+            st.ok(
+                is(ES.ToPrimitive(primitive), primitive),
+                `${primitive} is returned correctly`
+            );
+        };
+        forEach(primitives, testPrimitive);
+        st.end();
+    });
+
+    t.test('objects', st => {
+        st.equal(
+            ES.ToPrimitive(coercibleObject),
+            coercibleObject.valueOf(),
+            'coercibleObject coerces to valueOf'
+        );
+        st.equal(
+            ES.ToPrimitive(coercibleObject, Number),
+            coercibleObject.valueOf(),
+            'coercibleObject with hint Number coerces to valueOf'
+        );
+        st.equal(
+            ES.ToPrimitive(coercibleObject, String),
+            coercibleObject.toString(),
+            'coercibleObject with hint String coerces to toString'
+        );
+        st.equal(
+            ES.ToPrimitive(coercibleFnObject),
+            coercibleFnObject.toString(),
+            'coercibleFnObject coerces to toString'
+        );
+        st.equal(
+            ES.ToPrimitive(toStringOnlyObject),
+            toStringOnlyObject.toString(),
+            'toStringOnlyObject returns toString'
+        );
+        st.equal(
+            ES.ToPrimitive(valueOfOnlyObject),
+            valueOfOnlyObject.valueOf(),
+            'valueOfOnlyObject returns valueOf'
+        );
+        st.equal(
+            ES.ToPrimitive({}),
+            '[object Object]',
+            '{} with no hint coerces to Object#toString'
+        );
+        st.equal(
+            ES.ToPrimitive({}, String),
+            '[object Object]',
+            '{} with hint String coerces to Object#toString'
+        );
+        st.equal(
+            ES.ToPrimitive({}, Number),
+            '[object Object]',
+            '{} with hint Number coerces to Object#toString'
+        );
+        st.throws(
+            () => ES.ToPrimitive(uncoercibleObject),
+            TypeError,
+            'uncoercibleObject throws a TypeError'
+        );
+        st.throws(
+            () => ES.ToPrimitive(uncoercibleFnObject),
+            TypeError,
+            'uncoercibleFnObject throws a TypeError'
+        );
+        st.end();
+    });
+
+    t.end();
+});
+
+test('ToBoolean', t => {
+    t.equal(false, ES.ToBoolean(undefined), 'undefined coerces to false');
+    t.equal(false, ES.ToBoolean(null), 'null coerces to false');
+    t.equal(false, ES.ToBoolean(false), 'false returns false');
+    t.equal(true, ES.ToBoolean(true), 'true returns true');
+    forEach([0, -0, NaN], falsyNumber => {
+        t.equal(
+            false,
+            ES.ToBoolean(falsyNumber),
+            `falsy number ${falsyNumber} coerces to false`
+        );
+    });
+    forEach([Infinity, 42, 1, -Infinity], truthyNumber => {
+        t.equal(
+            true,
+            ES.ToBoolean(truthyNumber),
+            `truthy number ${truthyNumber} coerces to true`
+        );
+    });
+    t.equal(false, ES.ToBoolean(''), 'empty string coerces to false');
+    t.equal(true, ES.ToBoolean('foo'), 'nonempty string coerces to true');
+    forEach(objects, obj => {
+        t.equal(true, ES.ToBoolean(obj), 'object coerces to true');
+    });
+    t.equal(
+        true,
+        ES.ToBoolean(uncoercibleObject),
+        'uncoercibleObject coerces to true'
+    );
+    t.end();
+});
+
+test('ToNumber', t => {
+    t.ok(is(NaN, ES.ToNumber(undefined)), 'undefined coerces to NaN');
+    t.ok(is(ES.ToNumber(null), 0), 'null coerces to +0');
+    t.ok(is(ES.ToNumber(false), 0), 'false coerces to +0');
+    t.equal(1, ES.ToNumber(true), 'true coerces to 1');
+    t.ok(is(NaN, ES.ToNumber(NaN)), 'NaN returns itself');
+    forEach([0, -0, 42, Infinity, -Infinity], num => {
+        t.equal(num, ES.ToNumber(num), `${num} returns itself`);
+    });
+    forEach(['foo', '0', '4a', '2.0', 'Infinity', '-Infinity'], numString => {
+        t.ok(
+            is(+numString, ES.ToNumber(numString)),
+            `"${numString}" coerces to ${Number(numString)}`
+        );
+    });
+    forEach(objects, object => {
+        t.ok(
+            is(ES.ToNumber(object), ES.ToNumber(ES.ToPrimitive(object))),
+            `object ${object} coerces to same as ToPrimitive of object does`
+        );
+    });
+    t.throws(
+        () => ES.ToNumber(uncoercibleObject),
+        TypeError,
+        'uncoercibleObject throws'
+    );
+    t.end();
+});
+
+test('ToInteger', t => {
+    t.ok(is(0, ES.ToInteger(NaN)), 'NaN coerces to +0');
+    forEach([0, Infinity, 42], num => {
+        t.ok(is(num, ES.ToInteger(num)), `${num} returns itself`);
+        t.ok(is(-num, ES.ToInteger(-num)), `-${num} returns itself`);
+    });
+    t.equal(3, ES.ToInteger(Math.PI), 'pi returns 3');
+    t.throws(
+        () => ES.ToInteger(uncoercibleObject),
+        TypeError,
+        'uncoercibleObject throws'
+    );
+    t.end();
+});
+
+test('ToInt32', t => {
+    t.ok(is(0, ES.ToInt32(NaN)), 'NaN coerces to +0');
+    forEach([0, Infinity], num => {
+        t.ok(is(0, ES.ToInt32(num)), `${num} returns +0`);
+        t.ok(is(0, ES.ToInt32(-num)), `-${num} returns +0`);
+    });
+    t.throws(
+        () => ES.ToInt32(uncoercibleObject),
+        TypeError,
+        'uncoercibleObject throws'
+    );
+    t.ok(is(ES.ToInt32(0x100000000), 0), '2^32 returns +0');
+    t.ok(is(ES.ToInt32(0x100000000 - 1), -1), '2^32 - 1 returns -1');
+    t.ok(is(ES.ToInt32(0x80000000), -0x80000000), '2^31 returns -2^31');
+    t.ok(
+        is(ES.ToInt32(0x80000000 - 1), 0x80000000 - 1),
+        '2^31 - 1 returns 2^31 - 1'
+    );
+    forEach([0, Infinity, NaN, 0x100000000, 0x80000000, 0x10000, 0x42], num => {
+        t.ok(
+            is(ES.ToInt32(num), ES.ToInt32(ES.ToUint32(num))),
+            `ToInt32(x) === ToInt32(ToUint32(x)) for 0x${num.toString(16)}`
+        );
+        t.ok(
+            is(ES.ToInt32(-num), ES.ToInt32(ES.ToUint32(-num))),
+            `ToInt32(x) === ToInt32(ToUint32(x)) for -0x${num.toString(16)}`
+        );
+    });
+    t.end();
+});
+
+test('ToUint32', t => {
+    t.ok(is(0, ES.ToUint32(NaN)), 'NaN coerces to +0');
+    forEach([0, Infinity], num => {
+        t.ok(is(0, ES.ToUint32(num)), `${num} returns +0`);
+        t.ok(is(0, ES.ToUint32(-num)), `-${num} returns +0`);
+    });
+    t.throws(
+        () => ES.ToUint32(uncoercibleObject),
+        TypeError,
+        'uncoercibleObject throws'
+    );
+    t.ok(is(ES.ToUint32(0x100000000), 0), '2^32 returns +0');
+    t.ok(
+        is(ES.ToUint32(0x100000000 - 1), 0x100000000 - 1),
+        '2^32 - 1 returns 2^32 - 1'
+    );
+    t.ok(is(ES.ToUint32(0x80000000), 0x80000000), '2^31 returns 2^31');
+    t.ok(
+        is(ES.ToUint32(0x80000000 - 1), 0x80000000 - 1),
+        '2^31 - 1 returns 2^31 - 1'
+    );
+    forEach([0, Infinity, NaN, 0x100000000, 0x80000000, 0x10000, 0x42], num => {
+        t.ok(
+            is(ES.ToUint32(num), ES.ToUint32(ES.ToInt32(num))),
+            `ToUint32(x) === ToUint32(ToInt32(x)) for 0x${num.toString(16)}`
+        );
+        t.ok(
+            is(ES.ToUint32(-num), ES.ToUint32(ES.ToInt32(-num))),
+            `ToUint32(x) === ToUint32(ToInt32(x)) for -0x${num.toString(16)}`
+        );
+    });
+    t.end();
+});
+
+test('ToUint16', t => {
+    t.ok(is(0, ES.ToUint16(NaN)), 'NaN coerces to +0');
+    forEach([0, Infinity], num => {
+        t.ok(is(0, ES.ToUint16(num)), `${num} returns +0`);
+        t.ok(is(0, ES.ToUint16(-num)), `-${num} returns +0`);
+    });
+    t.throws(
+        () => ES.ToUint16(uncoercibleObject),
+        TypeError,
+        'uncoercibleObject throws'
+    );
+    t.ok(is(ES.ToUint16(0x100000000), 0), '2^32 returns +0');
+    t.ok(
+        is(ES.ToUint16(0x100000000 - 1), 0x10000 - 1),
+        '2^32 - 1 returns 2^16 - 1'
+    );
+    t.ok(is(ES.ToUint16(0x80000000), 0), '2^31 returns +0');
+    t.ok(
+        is(ES.ToUint16(0x80000000 - 1), 0x10000 - 1),
+        '2^31 - 1 returns 2^16 - 1'
+    );
+    t.ok(is(ES.ToUint16(0x10000), 0), '2^16 returns +0');
+    t.ok(
+        is(ES.ToUint16(0x10000 - 1), 0x10000 - 1),
+        '2^16 - 1 returns 2^16 - 1'
+    );
+    t.end();
+});
+
+test('ToString', t => {
+    t.throws(
+        () => ES.ToString(uncoercibleObject),
+        TypeError,
+        'uncoercibleObject throws'
+    );
+    t.end();
+});
+
+test('ToObject', t => {
+    t.throws(() => ES.ToObject(undefined), TypeError, 'undefined throws');
+    t.throws(() => ES.ToObject(null), TypeError, 'null throws');
+    forEach(numbers, number => {
+        const obj = ES.ToObject(number);
+        t.equal(typeof obj, 'object', `number ${number} coerces to object`);
+        t.equal(
+            true,
+            obj instanceof Number,
+            `object of ${number} is Number object`
+        );
+        t.ok(
+            is(obj.valueOf(), number),
+            `object of ${number} coerces to ${number}`
+        );
+    });
+    t.end();
+});
+
+test('CheckObjectCoercible', t => {
+    t.throws(
+        () => ES.CheckObjectCoercible(undefined),
+        TypeError,
+        'undefined throws'
+    );
+    t.throws(() => ES.CheckObjectCoercible(null), TypeError, 'null throws');
+    const checkCoercible = function(value) {
+        t.doesNotThrow(
+            () => ES.CheckObjectCoercible(value),
+            `"${value}" does not throw`
+        );
+    };
+    forEach(objects.concat(nonNullPrimitives), checkCoercible);
+    t.end();
+});
+
+test('IsCallable', t => {
+    t.equal(true, ES.IsCallable(() => {}), 'function is callable');
+    const nonCallables = [/a/g, {}, Object.prototype, NaN].concat(primitives);
+    forEach(nonCallables, nonCallable => {
+        t.equal(
+            false,
+            ES.IsCallable(nonCallable),
+            `${nonCallable} is not callable`
+        );
+    });
+    t.end();
+});
+
+test('SameValue', t => {
+    t.equal(true, ES.SameValue(NaN, NaN), 'NaN is SameValue as NaN');
+    t.equal(false, ES.SameValue(0, -0), '+0 is not SameValue as -0');
+    forEach(objects.concat(primitives), val => {
+        t.equal(
+            val === val,
+            ES.SameValue(val, val),
+            `"${val}" is SameValue to itself`
+        );
+    });
+    t.end();
+});
+
+test('Type', t => {
+    t.equal(ES.Type(), 'Undefined', 'Type() is Undefined');
+    t.equal(ES.Type(undefined), 'Undefined', 'Type(undefined) is Undefined');
+    t.equal(ES.Type(null), 'Null', 'Type(null) is Null');
+    t.equal(ES.Type(true), 'Boolean', 'Type(true) is Boolean');
+    t.equal(ES.Type(false), 'Boolean', 'Type(false) is Boolean');
+    t.equal(ES.Type(0), 'Number', 'Type(0) is Number');
+    t.equal(ES.Type(NaN), 'Number', 'Type(NaN) is Number');
+    t.equal(ES.Type('abc'), 'String', 'Type("abc") is String');
+    t.equal(ES.Type(() => {}), 'Object', 'Type(function () {}) is Object');
+    t.equal(ES.Type({}), 'Object', 'Type({}) is Object');
+    t.end();
+});
+
+const bothDescriptor = function() {
+    return { '[[Get]]'() {}, '[[Value]]': true };
+};
+const accessorDescriptor = function() {
+    return {
+        '[[Get]]'() {},
+        '[[Enumerable]]': true,
+        '[[Configurable]]': true,
+    };
+};
+const mutatorDescriptor = function() {
+    return {
+        '[[Set]]'() {},
+        '[[Enumerable]]': true,
+        '[[Configurable]]': true,
+    };
+};
+const dataDescriptor = function() {
+    return {
+        '[[Value]]': 42,
+        '[[Writable]]': false,
+        '[[Configurable]]': false,
+    };
+};
+const genericDescriptor = function() {
+    return {
+        '[[Configurable]]': true,
+        '[[Enumerable]]': false,
+    };
+};
+
+test('IsPropertyDescriptor', t => {
+    forEach(primitives, primitive => {
+        t.equal(
+            ES.IsPropertyDescriptor(primitive),
+            false,
+            `${primitive} is not a Property Descriptor`
+        );
+    });
+
+    t.equal(
+        ES.IsPropertyDescriptor({ invalid: true }),
+        false,
+        'invalid keys not allowed on a Property Descriptor'
+    );
+
+    t.equal(
+        ES.IsPropertyDescriptor({}),
+        true,
+        'empty object is an incomplete Property Descriptor'
+    );
+
+    t.equal(
+        ES.IsPropertyDescriptor(accessorDescriptor()),
+        true,
+        'accessor descriptor is a Property Descriptor'
+    );
+    t.equal(
+        ES.IsPropertyDescriptor(mutatorDescriptor()),
+        true,
+        'mutator descriptor is a Property Descriptor'
+    );
+    t.equal(
+        ES.IsPropertyDescriptor(dataDescriptor()),
+        true,
+        'data descriptor is a Property Descriptor'
+    );
+    t.equal(
+        ES.IsPropertyDescriptor(genericDescriptor()),
+        true,
+        'generic descriptor is a Property Descriptor'
+    );
+
+    t.throws(
+        () => {
+            ES.IsPropertyDescriptor(bothDescriptor());
+        },
+        TypeError,
+        'a Property Descriptor can not be both a Data and an Accessor Descriptor'
+    );
+
+    t.end();
+});
+
+test('IsAccessorDescriptor', t => {
+    forEach(nonNullPrimitives.concat(null), primitive => {
+        t.throws(
+            () => {
+                ES.IsAccessorDescriptor(primitive);
+            },
+            TypeError,
+            `${primitive} is not a Property Descriptor`
+        );
+    });
+
+    t.equal(
+        ES.IsAccessorDescriptor(),
+        false,
+        'no value is not an Accessor Descriptor'
+    );
+    t.equal(
+        ES.IsAccessorDescriptor(undefined),
+        false,
+        'undefined value is not an Accessor Descriptor'
+    );
+
+    t.equal(
+        ES.IsAccessorDescriptor(accessorDescriptor()),
+        true,
+        'accessor descriptor is an Accessor Descriptor'
+    );
+    t.equal(
+        ES.IsAccessorDescriptor(mutatorDescriptor()),
+        true,
+        'mutator descriptor is an Accessor Descriptor'
+    );
+    t.equal(
+        ES.IsAccessorDescriptor(dataDescriptor()),
+        false,
+        'data descriptor is not an Accessor Descriptor'
+    );
+    t.equal(
+        ES.IsAccessorDescriptor(genericDescriptor()),
+        false,
+        'generic descriptor is not an Accessor Descriptor'
+    );
+
+    t.end();
+});
+
+test('IsDataDescriptor', t => {
+    forEach(nonNullPrimitives.concat(null), primitive => {
+        t.throws(
+            () => {
+                ES.IsDataDescriptor(primitive);
+            },
+            TypeError,
+            `${primitive} is not a Property Descriptor`
+        );
+    });
+
+    t.equal(ES.IsDataDescriptor(), false, 'no value is not a Data Descriptor');
+    t.equal(
+        ES.IsDataDescriptor(undefined),
+        false,
+        'undefined value is not a Data Descriptor'
+    );
+
+    t.equal(
+        ES.IsDataDescriptor(accessorDescriptor()),
+        false,
+        'accessor descriptor is not a Data Descriptor'
+    );
+    t.equal(
+        ES.IsDataDescriptor(mutatorDescriptor()),
+        false,
+        'mutator descriptor is not a Data Descriptor'
+    );
+    t.equal(
+        ES.IsDataDescriptor(dataDescriptor()),
+        true,
+        'data descriptor is a Data Descriptor'
+    );
+    t.equal(
+        ES.IsDataDescriptor(genericDescriptor()),
+        false,
+        'generic descriptor is not a Data Descriptor'
+    );
+
+    t.end();
+});
+
+test('IsGenericDescriptor', t => {
+    forEach(nonNullPrimitives.concat(null), primitive => {
+        t.throws(
+            () => {
+                ES.IsGenericDescriptor(primitive);
+            },
+            TypeError,
+            `${primitive} is not a Property Descriptor`
+        );
+    });
+
+    t.equal(
+        ES.IsGenericDescriptor(),
+        false,
+        'no value is not a Data Descriptor'
+    );
+    t.equal(
+        ES.IsGenericDescriptor(undefined),
+        false,
+        'undefined value is not a Data Descriptor'
+    );
+
+    t.equal(
+        ES.IsGenericDescriptor(accessorDescriptor()),
+        false,
+        'accessor descriptor is not a generic Descriptor'
+    );
+    t.equal(
+        ES.IsGenericDescriptor(mutatorDescriptor()),
+        false,
+        'mutator descriptor is not a generic Descriptor'
+    );
+    t.equal(
+        ES.IsGenericDescriptor(dataDescriptor()),
+        false,
+        'data descriptor is not a generic Descriptor'
+    );
+
+    t.equal(
+        ES.IsGenericDescriptor(genericDescriptor()),
+        true,
+        'generic descriptor is a generic Descriptor'
+    );
+
+    t.end();
+});
+
+test('FromPropertyDescriptor', t => {
+    t.equal(
+        ES.FromPropertyDescriptor(),
+        undefined,
+        'no value begets undefined'
+    );
+    t.equal(
+        ES.FromPropertyDescriptor(undefined),
+        undefined,
+        'undefined value begets undefined'
+    );
+
+    forEach(nonNullPrimitives.concat(null), primitive => {
+        t.throws(
+            () => {
+                ES.FromPropertyDescriptor(primitive);
+            },
+            TypeError,
+            `${primitive} is not a Property Descriptor`
+        );
+    });
+
+    const accessor = accessorDescriptor();
+    t.deepEqual(ES.FromPropertyDescriptor(accessor), {
+        get: accessor['[[Get]]'],
+        set: accessor['[[Set]]'],
+        enumerable: !!accessor['[[Enumerable]]'],
+        configurable: !!accessor['[[Configurable]]'],
+    });
+
+    const mutator = mutatorDescriptor();
+    t.deepEqual(ES.FromPropertyDescriptor(mutator), {
+        get: mutator['[[Get]]'],
+        set: mutator['[[Set]]'],
+        enumerable: !!mutator['[[Enumerable]]'],
+        configurable: !!mutator['[[Configurable]]'],
+    });
+    const data = dataDescriptor();
+    t.deepEqual(ES.FromPropertyDescriptor(data), {
+        value: data['[[Value]]'],
+        writable: data['[[Writable]]'],
+        enumerable: !!data['[[Enumerable]]'],
+        configurable: !!data['[[Configurable]]'],
+    });
+
+    t.throws(
+        () => {
+            ES.FromPropertyDescriptor(genericDescriptor());
+        },
+        TypeError,
+        'a complete Property Descriptor is required'
+    );
+
+    t.end();
+});
+
+test('ToPropertyDescriptor', t => {
+    forEach(nonNullPrimitives.concat(null), primitive => {
+        t.throws(
+            () => {
+                ES.ToPropertyDescriptor(primitive);
+            },
+            TypeError,
+            `${primitive} is not an Object`
+        );
+    });
+
+    const accessor = accessorDescriptor();
+    t.deepEqual(
+        ES.ToPropertyDescriptor({
+            get: accessor['[[Get]]'],
+            enumerable: !!accessor['[[Enumerable]]'],
+            configurable: !!accessor['[[Configurable]]'],
+        }),
+        accessor
+    );
+
+    const mutator = mutatorDescriptor();
+    t.deepEqual(
+        ES.ToPropertyDescriptor({
+            set: mutator['[[Set]]'],
+            enumerable: !!mutator['[[Enumerable]]'],
+            configurable: !!mutator['[[Configurable]]'],
+        }),
+        mutator
+    );
+
+    const data = dataDescriptor();
+    t.deepEqual(
+        ES.ToPropertyDescriptor({
+            value: data['[[Value]]'],
+            writable: data['[[Writable]]'],
+            configurable: !!data['[[Configurable]]'],
+        }),
+        data
+    );
+
+    const both = bothDescriptor();
+    t.throws(
+        () => {
+            ES.ToPropertyDescriptor({
+                get: both['[[Get]]'],
+                value: both['[[Value]]'],
+            });
+        },
+        TypeError,
+        'data and accessor descriptors are mutually exclusive'
+    );
+
+    t.throws(
+        () => {
+            ES.ToPropertyDescriptor({ get: 'not callable' });
+        },
+        TypeError,
+        '"get" must be undefined or callable'
+    );
+
+    t.throws(
+        () => {
+            ES.ToPropertyDescriptor({ set: 'not callable' });
+        },
+        TypeError,
+        '"set" must be undefined or callable'
+    );
+
+    t.end();
+});

--- a/test/mock/identical-implementation/node_modules/es-abstract/test/es6.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/test/es6.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const test = require('tape');
+
+const ES = require('../');
+const ES6 = ES.ES6;
+const ES2015 = ES.ES2015;
+const ES6entry = require('../es6');
+
+test('legacy es6 export', t => {
+    t.equal(ES6, ES2015, 'main ES6 === main ES2015');
+    t.end();
+});
+
+test('legacy es6 entry point', t => {
+    t.equal(ES6, ES6entry, 'main ES6 === ES6 entry point');
+    t.end();
+});

--- a/test/mock/identical-implementation/node_modules/es-abstract/test/es7.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/test/es7.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const test = require('tape');
+
+const ES = require('../');
+const ES7 = ES.ES7;
+const ES2016 = ES.ES2016;
+const ES7entry = require('../es7');
+
+test('legacy es7 export', t => {
+    t.equal(ES7, ES2016, 'main ES7 === main ES2016');
+    t.end();
+});
+
+test('legacy es7 entry point', t => {
+    t.equal(ES7, ES7entry, 'main ES7 === ES7 entry point');
+    t.end();
+});

--- a/test/mock/identical-implementation/node_modules/es-abstract/test/helpers/values.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/test/helpers/values.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const hasSymbols =
+    typeof Symbol === 'function' && typeof Symbol.iterator === 'symbol';
+
+const coercibleObject = {
+    valueOf() {
+        return 3;
+    },
+    toString() {
+        return 42;
+    },
+};
+const valueOfOnlyObject = {
+    valueOf() {
+        return 4;
+    },
+    toString() {
+        return {};
+    },
+};
+const toStringOnlyObject = {
+    valueOf() {
+        return {};
+    },
+    toString() {
+        return 7;
+    },
+};
+const uncoercibleObject = {
+    valueOf() {
+        return {};
+    },
+    toString() {
+        return {};
+    },
+};
+const objects = [{}, coercibleObject, toStringOnlyObject, valueOfOnlyObject];
+const nullPrimitives = [undefined, null];
+const nonIntegerNumbers = [-1.3, 0.2, 1.8, 1 / 3];
+const numbers = [0, -0, Infinity, -Infinity, 42];
+const strings = ['', 'foo'];
+const booleans = [true, false];
+const symbols = hasSymbols ? [Symbol.iterator, Symbol('foo')] : [];
+const nonSymbolPrimitives = [].concat(
+    nullPrimitives,
+    booleans,
+    strings,
+    numbers
+);
+const nonNumberPrimitives = [].concat(
+    nullPrimitives,
+    booleans,
+    strings,
+    symbols
+);
+const nonNullPrimitives = [].concat(booleans, strings, numbers, symbols);
+const nonUndefinedPrimitives = [].concat(null, nonNullPrimitives);
+const nonStrings = [].concat(
+    nullPrimitives,
+    booleans,
+    numbers,
+    symbols,
+    objects
+);
+const primitives = [].concat(nullPrimitives, nonNullPrimitives);
+const nonPropertyKeys = [].concat(nullPrimitives, booleans, numbers, objects);
+const propertyKeys = [].concat(strings, symbols);
+const nonBooleans = [].concat(
+    nullPrimitives,
+    strings,
+    symbols,
+    numbers,
+    objects
+);
+const falsies = [].concat(nullPrimitives, false, '', 0, -0, NaN);
+const truthies = [].concat(true, 'foo', 42, symbols, objects);
+
+module.exports = {
+    coercibleObject,
+    valueOfOnlyObject,
+    toStringOnlyObject,
+    uncoercibleObject,
+    objects,
+    nullPrimitives,
+    numbers,
+    strings,
+    booleans,
+    symbols,
+    hasSymbols,
+    nonSymbolPrimitives,
+    nonNumberPrimitives,
+    nonNullPrimitives,
+    nonUndefinedPrimitives,
+    nonStrings,
+    nonNumbers: nonNumberPrimitives.concat(objects),
+    nonIntegerNumbers,
+    primitives,
+    nonPropertyKeys,
+    propertyKeys,
+    nonBooleans,
+    falsies,
+    truthies,
+};

--- a/test/mock/identical-implementation/node_modules/es-abstract/test/index.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/test/index.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const ES = require('../');
+const test = require('tape');
+
+const ESkeys = Object.keys(ES).sort();
+const ES6keys = Object.keys(ES.ES6).sort();
+
+test('exposed properties', t => {
+    t.deepEqual(
+        ESkeys,
+        ES6keys.concat([
+            'ES2017',
+            'ES7',
+            'ES2016',
+            'ES6',
+            'ES2015',
+            'ES5',
+        ]).sort(),
+        'main ES object keys match ES6 keys'
+    );
+    t.end();
+});
+
+test('methods match', t => {
+    ES6keys.forEach(key => {
+        t.equal(
+            ES.ES6[key],
+            ES[key],
+            `method ${key} on main ES object is ES6 method`
+        );
+    });
+    t.end();
+});
+
+require('./es5');
+require('./es6');
+require('./es2015');
+require('./es7');
+require('./es2016');
+require('./es2017');

--- a/test/mock/identical-implementation/node_modules/es-abstract/test/tests.js
+++ b/test/mock/identical-implementation/node_modules/es-abstract/test/tests.js
@@ -1,0 +1,2412 @@
+'use strict';
+
+const test = require('tape');
+
+const forEach = require('foreach');
+const is = require('object-is');
+const debug = require('util').format;
+const assign = require('object.assign');
+
+const v = require('./helpers/values');
+const diffOps = require('./diffOps');
+
+const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER || Math.pow(2, 53) - 1;
+
+const getArraySubclassWithSpeciesConstructor = function getArraySubclass(
+    speciesConstructor
+) {
+    const Bar = function Bar() {
+        const inst = [];
+        Object.setPrototypeOf(inst, Bar.prototype);
+        Object.defineProperty(inst, 'constructor', { value: Bar });
+        return inst;
+    };
+    Bar.prototype = Object.create(Array.prototype);
+    Object.setPrototypeOf(Bar, Array);
+    Object.defineProperty(Bar, Symbol.species, { value: speciesConstructor });
+
+    return Bar;
+};
+
+const hasSpecies = v.hasSymbols && Symbol.species;
+
+const es2015 = function ES2015(ES, ops, expectedMissing) {
+    test('has expected operations', t => {
+        const diff = diffOps(ES, ops);
+
+        t.deepEqual(diff.extra, [], 'no extra ops');
+
+        t.deepEqual(diff.missing, expectedMissing, 'no unexpected missing ops');
+
+        t.end();
+    });
+
+    test('ToPrimitive', t => {
+        t.test('primitives', st => {
+            const testPrimitive = function(primitive) {
+                st.ok(
+                    is(ES.ToPrimitive(primitive), primitive),
+                    `${debug(primitive)} is returned correctly`
+                );
+            };
+            forEach(v.primitives, testPrimitive);
+            st.end();
+        });
+
+        t.test('objects', st => {
+            st.equal(
+                ES.ToPrimitive(v.coercibleObject),
+                3,
+                'coercibleObject with no hint coerces to valueOf'
+            );
+            st.ok(
+                is(ES.ToPrimitive({}), '[object Object]'),
+                '{} with no hint coerces to Object#toString'
+            );
+            st.equal(
+                ES.ToPrimitive(v.coercibleObject, Number),
+                3,
+                'coercibleObject with hint Number coerces to valueOf'
+            );
+            st.ok(
+                is(ES.ToPrimitive({}, Number), '[object Object]'),
+                '{} with hint Number coerces to NaN'
+            );
+            st.equal(
+                ES.ToPrimitive(v.coercibleObject, String),
+                42,
+                'coercibleObject with hint String coerces to nonstringified toString'
+            );
+            st.equal(
+                ES.ToPrimitive({}, String),
+                '[object Object]',
+                '{} with hint String coerces to Object#toString'
+            );
+            st.equal(
+                ES.ToPrimitive(v.toStringOnlyObject),
+                7,
+                'toStringOnlyObject returns non-stringified toString'
+            );
+            st.equal(
+                ES.ToPrimitive(v.valueOfOnlyObject),
+                4,
+                'valueOfOnlyObject returns valueOf'
+            );
+            st.throws(
+                () => ES.ToPrimitive(v.uncoercibleObject),
+                TypeError,
+                'uncoercibleObject throws a TypeError'
+            );
+            st.end();
+        });
+
+        t.test('dates', st => {
+            const invalid = new Date(NaN);
+            st.equal(
+                ES.ToPrimitive(invalid),
+                Date.prototype.toString.call(invalid),
+                'invalid Date coerces to Date#toString'
+            );
+            const now = new Date();
+            st.equal(
+                ES.ToPrimitive(now),
+                Date.prototype.toString.call(now),
+                'Date coerces to Date#toString'
+            );
+            st.end();
+        });
+
+        t.end();
+    });
+
+    test('ToBoolean', t => {
+        t.equal(false, ES.ToBoolean(undefined), 'undefined coerces to false');
+        t.equal(false, ES.ToBoolean(null), 'null coerces to false');
+        t.equal(false, ES.ToBoolean(false), 'false returns false');
+        t.equal(true, ES.ToBoolean(true), 'true returns true');
+
+        t.test('numbers', st => {
+            forEach([0, -0, NaN], falsyNumber => {
+                st.equal(
+                    false,
+                    ES.ToBoolean(falsyNumber),
+                    `falsy number ${falsyNumber} coerces to false`
+                );
+            });
+            forEach([Infinity, 42, 1, -Infinity], truthyNumber => {
+                st.equal(
+                    true,
+                    ES.ToBoolean(truthyNumber),
+                    `truthy number ${truthyNumber} coerces to true`
+                );
+            });
+
+            st.end();
+        });
+
+        t.equal(false, ES.ToBoolean(''), 'empty string coerces to false');
+        t.equal(true, ES.ToBoolean('foo'), 'nonempty string coerces to true');
+
+        t.test('objects', st => {
+            forEach(v.objects, obj => {
+                st.equal(true, ES.ToBoolean(obj), 'object coerces to true');
+            });
+            st.equal(
+                true,
+                ES.ToBoolean(v.uncoercibleObject),
+                'uncoercibleObject coerces to true'
+            );
+
+            st.end();
+        });
+
+        t.end();
+    });
+
+    test('ToNumber', t => {
+        t.ok(is(NaN, ES.ToNumber(undefined)), 'undefined coerces to NaN');
+        t.ok(is(ES.ToNumber(null), 0), 'null coerces to +0');
+        t.ok(is(ES.ToNumber(false), 0), 'false coerces to +0');
+        t.equal(1, ES.ToNumber(true), 'true coerces to 1');
+
+        t.test('numbers', st => {
+            st.ok(is(NaN, ES.ToNumber(NaN)), 'NaN returns itself');
+            forEach([0, -0, 42, Infinity, -Infinity], num => {
+                st.equal(num, ES.ToNumber(num), `${num} returns itself`);
+            });
+            forEach(
+                ['foo', '0', '4a', '2.0', 'Infinity', '-Infinity'],
+                numString => {
+                    st.ok(
+                        is(+numString, ES.ToNumber(numString)),
+                        `"${numString}" coerces to ${Number(numString)}`
+                    );
+                }
+            );
+            st.end();
+        });
+
+        t.test('objects', st => {
+            forEach(v.objects, object => {
+                st.ok(
+                    is(
+                        ES.ToNumber(object),
+                        ES.ToNumber(ES.ToPrimitive(object))
+                    ),
+                    `object ${object} coerces to same as ToPrimitive of object does`
+                );
+            });
+            st.throws(
+                () => ES.ToNumber(v.uncoercibleObject),
+                TypeError,
+                'uncoercibleObject throws'
+            );
+            st.end();
+        });
+
+        t.test('binary literals', st => {
+            st.equal(ES.ToNumber('0b10'), 2, '0b10 is 2');
+            st.equal(
+                ES.ToNumber({
+                    toString() {
+                        return '0b11';
+                    },
+                }),
+                3,
+                'Object that toStrings to 0b11 is 3'
+            );
+
+            st.equal(true, is(ES.ToNumber('0b12'), NaN), '0b12 is NaN');
+            st.equal(
+                true,
+                is(
+                    ES.ToNumber({
+                        toString() {
+                            return '0b112';
+                        },
+                    }),
+                    NaN
+                ),
+                'Object that toStrings to 0b112 is NaN'
+            );
+            st.end();
+        });
+
+        t.test('octal literals', st => {
+            st.equal(ES.ToNumber('0o10'), 8, '0o10 is 8');
+            st.equal(
+                ES.ToNumber({
+                    toString() {
+                        return '0o11';
+                    },
+                }),
+                9,
+                'Object that toStrings to 0o11 is 9'
+            );
+
+            st.equal(true, is(ES.ToNumber('0o18'), NaN), '0o18 is NaN');
+            st.equal(
+                true,
+                is(
+                    ES.ToNumber({
+                        toString() {
+                            return '0o118';
+                        },
+                    }),
+                    NaN
+                ),
+                'Object that toStrings to 0o118 is NaN'
+            );
+            st.end();
+        });
+
+        t.test('signed hex numbers', st => {
+            st.equal(true, is(ES.ToNumber('-0xF'), NaN), '-0xF is NaN');
+            st.equal(
+                true,
+                is(ES.ToNumber(' -0xF '), NaN),
+                'space-padded -0xF is NaN'
+            );
+            st.equal(true, is(ES.ToNumber('+0xF'), NaN), '+0xF is NaN');
+            st.equal(
+                true,
+                is(ES.ToNumber(' +0xF '), NaN),
+                'space-padded +0xF is NaN'
+            );
+
+            st.end();
+        });
+
+        t.test('trimming of whitespace and non-whitespace characters', st => {
+            const whitespace =
+                ' \t\x0b\f\xa0\ufeff\n\r\u2028\u2029\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000';
+            st.equal(
+                0,
+                ES.ToNumber(whitespace + 0 + whitespace),
+                'whitespace is trimmed'
+            );
+
+            // Zero-width space (zws), next line character (nel), and non-character (bom) are not whitespace.
+            const nonWhitespaces = {
+                '\\u0085': '\u0085',
+                '\\u200b': '\u200b',
+                '\\ufffe': '\ufffe',
+            };
+
+            forEach(nonWhitespaces, (desc, nonWS) => {
+                st.equal(
+                    true,
+                    is(ES.ToNumber(nonWS + 0 + nonWS), NaN),
+                    `non-whitespace ${desc} not trimmed`
+                );
+            });
+
+            st.end();
+        });
+
+        forEach(v.symbols, symbol => {
+            t.throws(
+                () => {
+                    ES.ToNumber(symbol);
+                },
+                TypeError,
+                `Symbols can’t be converted to a Number: ${debug(symbol)}`
+            );
+        });
+
+        t.test('dates', st => {
+            const invalid = new Date(NaN);
+            st.ok(is(ES.ToNumber(invalid), NaN), 'invalid Date coerces to NaN');
+            const now = Date.now();
+            st.equal(
+                ES.ToNumber(new Date(now)),
+                now,
+                'Date coerces to timestamp'
+            );
+            st.end();
+        });
+
+        t.end();
+    });
+
+    test('ToInteger', t => {
+        t.ok(is(0, ES.ToInteger(NaN)), 'NaN coerces to +0');
+        forEach([0, Infinity, 42], num => {
+            t.ok(is(num, ES.ToInteger(num)), `${num} returns itself`);
+            t.ok(is(-num, ES.ToInteger(-num)), `-${num} returns itself`);
+        });
+        t.equal(3, ES.ToInteger(Math.PI), 'pi returns 3');
+        t.throws(
+            () => ES.ToInteger(v.uncoercibleObject),
+            TypeError,
+            'uncoercibleObject throws'
+        );
+        t.end();
+    });
+
+    test('ToInt32', t => {
+        t.ok(is(0, ES.ToInt32(NaN)), 'NaN coerces to +0');
+        forEach([0, Infinity], num => {
+            t.ok(is(0, ES.ToInt32(num)), `${num} returns +0`);
+            t.ok(is(0, ES.ToInt32(-num)), `-${num} returns +0`);
+        });
+        t.throws(
+            () => ES.ToInt32(v.uncoercibleObject),
+            TypeError,
+            'uncoercibleObject throws'
+        );
+        t.ok(is(ES.ToInt32(0x100000000), 0), '2^32 returns +0');
+        t.ok(is(ES.ToInt32(0x100000000 - 1), -1), '2^32 - 1 returns -1');
+        t.ok(is(ES.ToInt32(0x80000000), -0x80000000), '2^31 returns -2^31');
+        t.ok(
+            is(ES.ToInt32(0x80000000 - 1), 0x80000000 - 1),
+            '2^31 - 1 returns 2^31 - 1'
+        );
+        forEach(
+            [0, Infinity, NaN, 0x100000000, 0x80000000, 0x10000, 0x42],
+            num => {
+                t.ok(
+                    is(ES.ToInt32(num), ES.ToInt32(ES.ToUint32(num))),
+                    `ToInt32(x) === ToInt32(ToUint32(x)) for 0x${num.toString(
+                        16
+                    )}`
+                );
+                t.ok(
+                    is(ES.ToInt32(-num), ES.ToInt32(ES.ToUint32(-num))),
+                    `ToInt32(x) === ToInt32(ToUint32(x)) for -0x${num.toString(
+                        16
+                    )}`
+                );
+            }
+        );
+        t.end();
+    });
+
+    test('ToUint32', t => {
+        t.ok(is(0, ES.ToUint32(NaN)), 'NaN coerces to +0');
+        forEach([0, Infinity], num => {
+            t.ok(is(0, ES.ToUint32(num)), `${num} returns +0`);
+            t.ok(is(0, ES.ToUint32(-num)), `-${num} returns +0`);
+        });
+        t.throws(
+            () => ES.ToUint32(v.uncoercibleObject),
+            TypeError,
+            'uncoercibleObject throws'
+        );
+        t.ok(is(ES.ToUint32(0x100000000), 0), '2^32 returns +0');
+        t.ok(
+            is(ES.ToUint32(0x100000000 - 1), 0x100000000 - 1),
+            '2^32 - 1 returns 2^32 - 1'
+        );
+        t.ok(is(ES.ToUint32(0x80000000), 0x80000000), '2^31 returns 2^31');
+        t.ok(
+            is(ES.ToUint32(0x80000000 - 1), 0x80000000 - 1),
+            '2^31 - 1 returns 2^31 - 1'
+        );
+        forEach(
+            [0, Infinity, NaN, 0x100000000, 0x80000000, 0x10000, 0x42],
+            num => {
+                t.ok(
+                    is(ES.ToUint32(num), ES.ToUint32(ES.ToInt32(num))),
+                    `ToUint32(x) === ToUint32(ToInt32(x)) for 0x${num.toString(
+                        16
+                    )}`
+                );
+                t.ok(
+                    is(ES.ToUint32(-num), ES.ToUint32(ES.ToInt32(-num))),
+                    `ToUint32(x) === ToUint32(ToInt32(x)) for -0x${num.toString(
+                        16
+                    )}`
+                );
+            }
+        );
+        t.end();
+    });
+
+    test('ToInt16', t => {
+        t.ok(is(0, ES.ToInt16(NaN)), 'NaN coerces to +0');
+        forEach([0, Infinity], num => {
+            t.ok(is(0, ES.ToInt16(num)), `${num} returns +0`);
+            t.ok(is(0, ES.ToInt16(-num)), `-${num} returns +0`);
+        });
+        t.throws(
+            () => ES.ToInt16(v.uncoercibleObject),
+            TypeError,
+            'uncoercibleObject throws'
+        );
+        t.ok(is(ES.ToInt16(0x100000000), 0), '2^32 returns +0');
+        t.ok(is(ES.ToInt16(0x100000000 - 1), -1), '2^32 - 1 returns -1');
+        t.ok(is(ES.ToInt16(0x80000000), 0), '2^31 returns +0');
+        t.ok(is(ES.ToInt16(0x80000000 - 1), -1), '2^31 - 1 returns -1');
+        t.ok(is(ES.ToInt16(0x10000), 0), '2^16 returns +0');
+        t.ok(is(ES.ToInt16(0x10000 - 1), -1), '2^16 - 1 returns -1');
+        t.end();
+    });
+
+    test('ToUint16', t => {
+        t.ok(is(0, ES.ToUint16(NaN)), 'NaN coerces to +0');
+        forEach([0, Infinity], num => {
+            t.ok(is(0, ES.ToUint16(num)), `${num} returns +0`);
+            t.ok(is(0, ES.ToUint16(-num)), `-${num} returns +0`);
+        });
+        t.throws(
+            () => ES.ToUint16(v.uncoercibleObject),
+            TypeError,
+            'uncoercibleObject throws'
+        );
+        t.ok(is(ES.ToUint16(0x100000000), 0), '2^32 returns +0');
+        t.ok(
+            is(ES.ToUint16(0x100000000 - 1), 0x10000 - 1),
+            '2^32 - 1 returns 2^16 - 1'
+        );
+        t.ok(is(ES.ToUint16(0x80000000), 0), '2^31 returns +0');
+        t.ok(
+            is(ES.ToUint16(0x80000000 - 1), 0x10000 - 1),
+            '2^31 - 1 returns 2^16 - 1'
+        );
+        t.ok(is(ES.ToUint16(0x10000), 0), '2^16 returns +0');
+        t.ok(
+            is(ES.ToUint16(0x10000 - 1), 0x10000 - 1),
+            '2^16 - 1 returns 2^16 - 1'
+        );
+        t.end();
+    });
+
+    test('ToInt8', t => {
+        t.ok(is(0, ES.ToInt8(NaN)), 'NaN coerces to +0');
+        forEach([0, Infinity], num => {
+            t.ok(is(0, ES.ToInt8(num)), `${num} returns +0`);
+            t.ok(is(0, ES.ToInt8(-num)), `-${num} returns +0`);
+        });
+        t.throws(
+            () => ES.ToInt8(v.uncoercibleObject),
+            TypeError,
+            'uncoercibleObject throws'
+        );
+        t.ok(is(ES.ToInt8(0x100000000), 0), '2^32 returns +0');
+        t.ok(is(ES.ToInt8(0x100000000 - 1), -1), '2^32 - 1 returns -1');
+        t.ok(is(ES.ToInt8(0x80000000), 0), '2^31 returns +0');
+        t.ok(is(ES.ToInt8(0x80000000 - 1), -1), '2^31 - 1 returns -1');
+        t.ok(is(ES.ToInt8(0x10000), 0), '2^16 returns +0');
+        t.ok(is(ES.ToInt8(0x10000 - 1), -1), '2^16 - 1 returns -1');
+        t.ok(is(ES.ToInt8(0x100), 0), '2^8 returns +0');
+        t.ok(is(ES.ToInt8(0x100 - 1), -1), '2^8 - 1 returns -1');
+        t.ok(is(ES.ToInt8(0x10), 0x10), '2^4 returns 2^4');
+        t.end();
+    });
+
+    test('ToUint8', t => {
+        t.ok(is(0, ES.ToUint8(NaN)), 'NaN coerces to +0');
+        forEach([0, Infinity], num => {
+            t.ok(is(0, ES.ToUint8(num)), `${num} returns +0`);
+            t.ok(is(0, ES.ToUint8(-num)), `-${num} returns +0`);
+        });
+        t.throws(
+            () => ES.ToUint8(v.uncoercibleObject),
+            TypeError,
+            'uncoercibleObject throws'
+        );
+        t.ok(is(ES.ToUint8(0x100000000), 0), '2^32 returns +0');
+        t.ok(
+            is(ES.ToUint8(0x100000000 - 1), 0x100 - 1),
+            '2^32 - 1 returns 2^8 - 1'
+        );
+        t.ok(is(ES.ToUint8(0x80000000), 0), '2^31 returns +0');
+        t.ok(
+            is(ES.ToUint8(0x80000000 - 1), 0x100 - 1),
+            '2^31 - 1 returns 2^8 - 1'
+        );
+        t.ok(is(ES.ToUint8(0x10000), 0), '2^16 returns +0');
+        t.ok(
+            is(ES.ToUint8(0x10000 - 1), 0x100 - 1),
+            '2^16 - 1 returns 2^8 - 1'
+        );
+        t.ok(is(ES.ToUint8(0x100), 0), '2^8 returns +0');
+        t.ok(is(ES.ToUint8(0x100 - 1), 0x100 - 1), '2^8 - 1 returns 2^16 - 1');
+        t.ok(is(ES.ToUint8(0x10), 0x10), '2^4 returns 2^4');
+        t.ok(is(ES.ToUint8(0x10 - 1), 0x10 - 1), '2^4 - 1 returns 2^4 - 1');
+        t.end();
+    });
+
+    test('ToUint8Clamp', t => {
+        t.ok(is(0, ES.ToUint8Clamp(NaN)), 'NaN coerces to +0');
+        t.ok(is(0, ES.ToUint8Clamp(0)), '+0 returns +0');
+        t.ok(is(0, ES.ToUint8Clamp(-0)), '-0 returns +0');
+        t.ok(is(0, ES.ToUint8Clamp(-Infinity)), '-Infinity returns +0');
+        t.throws(
+            () => ES.ToUint8Clamp(v.uncoercibleObject),
+            TypeError,
+            'uncoercibleObject throws'
+        );
+        forEach([255, 256, 0x100000, Infinity], number => {
+            t.ok(is(255, ES.ToUint8Clamp(number)), `${number} coerces to 255`);
+        });
+        t.equal(1, ES.ToUint8Clamp(1.49), '1.49 coerces to 1');
+        t.equal(2, ES.ToUint8Clamp(1.5), '1.5 coerces to 2, because 2 is even');
+        t.equal(2, ES.ToUint8Clamp(1.51), '1.51 coerces to 2');
+
+        t.equal(2, ES.ToUint8Clamp(2.49), '2.49 coerces to 2');
+        t.equal(2, ES.ToUint8Clamp(2.5), '2.5 coerces to 2, because 2 is even');
+        t.equal(3, ES.ToUint8Clamp(2.51), '2.51 coerces to 3');
+        t.end();
+    });
+
+    test('ToString', t => {
+        forEach(v.objects.concat(v.nonSymbolPrimitives), item => {
+            t.equal(
+                ES.ToString(item),
+                String(item),
+                `ES.ToString(${debug(item)}) ToStrings to String(${debug(
+                    item
+                )})`
+            );
+        });
+
+        t.throws(
+            () => ES.ToString(v.uncoercibleObject),
+            TypeError,
+            'uncoercibleObject throws'
+        );
+
+        forEach(v.symbols, symbol => {
+            t.throws(
+                () => ES.ToString(symbol),
+                TypeError,
+                `${debug(symbol)} throws`
+            );
+        });
+        t.end();
+    });
+
+    test('ToObject', t => {
+        t.throws(() => ES.ToObject(undefined), TypeError, 'undefined throws');
+        t.throws(() => ES.ToObject(null), TypeError, 'null throws');
+        forEach(v.numbers, number => {
+            const obj = ES.ToObject(number);
+            t.equal(typeof obj, 'object', `number ${number} coerces to object`);
+            t.equal(
+                true,
+                obj instanceof Number,
+                `object of ${number} is Number object`
+            );
+            t.ok(
+                is(obj.valueOf(), number),
+                `object of ${number} coerces to ${number}`
+            );
+        });
+        t.end();
+    });
+
+    test('RequireObjectCoercible', t => {
+        t.equal(
+            false,
+            'CheckObjectCoercible' in ES,
+            'CheckObjectCoercible -> RequireObjectCoercible in ES6'
+        );
+        t.throws(
+            () => ES.RequireObjectCoercible(undefined),
+            TypeError,
+            'undefined throws'
+        );
+        t.throws(
+            () => ES.RequireObjectCoercible(null),
+            TypeError,
+            'null throws'
+        );
+        const isCoercible = function(value) {
+            t.doesNotThrow(
+                () => ES.RequireObjectCoercible(value),
+                `${debug(value)} does not throw`
+            );
+        };
+        forEach(v.objects.concat(v.nonNullPrimitives), isCoercible);
+        t.end();
+    });
+
+    test('IsCallable', t => {
+        t.equal(true, ES.IsCallable(() => {}), 'function is callable');
+        const nonCallables = [/a/g, {}, Object.prototype, NaN].concat(
+            v.primitives
+        );
+        forEach(nonCallables, nonCallable => {
+            t.equal(
+                false,
+                ES.IsCallable(nonCallable),
+                `${debug(nonCallable)} is not callable`
+            );
+        });
+        t.end();
+    });
+
+    test('SameValue', t => {
+        t.equal(true, ES.SameValue(NaN, NaN), 'NaN is SameValue as NaN');
+        t.equal(false, ES.SameValue(0, -0), '+0 is not SameValue as -0');
+        forEach(v.objects.concat(v.primitives), val => {
+            t.equal(
+                val === val,
+                ES.SameValue(val, val),
+                `${debug(val)} is SameValue to itself`
+            );
+        });
+        t.end();
+    });
+
+    test('SameValueZero', t => {
+        t.equal(
+            true,
+            ES.SameValueZero(NaN, NaN),
+            'NaN is SameValueZero as NaN'
+        );
+        t.equal(true, ES.SameValueZero(0, -0), '+0 is SameValueZero as -0');
+        forEach(v.objects.concat(v.primitives), val => {
+            t.equal(
+                val === val,
+                ES.SameValueZero(val, val),
+                `${debug(val)} is SameValueZero to itself`
+            );
+        });
+        t.end();
+    });
+
+    test('ToPropertyKey', t => {
+        forEach(v.objects.concat(v.nonSymbolPrimitives), value => {
+            t.equal(
+                ES.ToPropertyKey(value),
+                String(value),
+                'ToPropertyKey(value) === String(value) for non-Symbols'
+            );
+        });
+
+        forEach(v.symbols, symbol => {
+            t.equal(
+                ES.ToPropertyKey(symbol),
+                symbol,
+                `ToPropertyKey(${debug(symbol)}) === ${debug(symbol)}`
+            );
+            t.equal(
+                ES.ToPropertyKey(Object(symbol)),
+                symbol,
+                `ToPropertyKey(${debug(Object(symbol))}) === ${debug(symbol)}`
+            );
+        });
+
+        t.end();
+    });
+
+    test('ToLength', t => {
+        t.throws(
+            () => ES.ToLength(v.uncoercibleObject),
+            TypeError,
+            'uncoercibleObject throws a TypeError'
+        );
+        t.equal(
+            3,
+            ES.ToLength(v.coercibleObject),
+            'coercibleObject coerces to 3'
+        );
+        t.equal(42, ES.ToLength('42.5'), '"42.5" coerces to 42');
+        t.equal(7, ES.ToLength(7.3), '7.3 coerces to 7');
+        forEach([-0, -1, -42, -Infinity], negative => {
+            t.ok(is(0, ES.ToLength(negative)), `${negative} coerces to +0`);
+        });
+        t.equal(
+            MAX_SAFE_INTEGER,
+            ES.ToLength(MAX_SAFE_INTEGER + 1),
+            '2^53 coerces to 2^53 - 1'
+        );
+        t.equal(
+            MAX_SAFE_INTEGER,
+            ES.ToLength(MAX_SAFE_INTEGER + 3),
+            '2^53 + 2 coerces to 2^53 - 1'
+        );
+        t.end();
+    });
+
+    test('IsArray', t => {
+        t.equal(true, ES.IsArray([]), '[] is array');
+        t.equal(false, ES.IsArray({}), '{} is not array');
+        t.equal(
+            false,
+            ES.IsArray({ length: 1, 0: true }),
+            'arraylike object is not array'
+        );
+        forEach(v.objects.concat(v.primitives), value => {
+            t.equal(false, ES.IsArray(value), `${debug(value)} is not array`);
+        });
+        t.end();
+    });
+
+    test('IsRegExp', t => {
+        forEach([/a/g, new RegExp('a', 'g')], regex => {
+            t.equal(true, ES.IsRegExp(regex), `${regex} is regex`);
+        });
+
+        forEach(v.objects.concat(v.primitives), nonRegex => {
+            t.equal(
+                false,
+                ES.IsRegExp(nonRegex),
+                `${debug(nonRegex)} is not regex`
+            );
+        });
+
+        t.test('Symbol.match', { skip: !v.hasSymbols || !Symbol.match }, st => {
+            const obj = {};
+            obj[Symbol.match] = true;
+            st.equal(
+                true,
+                ES.IsRegExp(obj),
+                'object with truthy Symbol.match is regex'
+            );
+
+            const regex = /a/;
+            regex[Symbol.match] = false;
+            st.equal(
+                false,
+                ES.IsRegExp(regex),
+                'regex with falsy Symbol.match is not regex'
+            );
+
+            st.end();
+        });
+
+        t.end();
+    });
+
+    test('IsPropertyKey', t => {
+        forEach(v.numbers.concat(v.objects), notKey => {
+            t.equal(
+                false,
+                ES.IsPropertyKey(notKey),
+                `${debug(notKey)} is not property key`
+            );
+        });
+
+        t.equal(true, ES.IsPropertyKey('foo'), 'string is property key');
+
+        forEach(v.symbols, symbol => {
+            t.equal(
+                true,
+                ES.IsPropertyKey(symbol),
+                `${debug(symbol)} is property key`
+            );
+        });
+        t.end();
+    });
+
+    test('IsInteger', t => {
+        for (let i = -100; i < 100; i += 10) {
+            t.equal(true, ES.IsInteger(i), `${i} is integer`);
+            t.equal(false, ES.IsInteger(i + 0.2), `${i + 0.2} is not integer`);
+        }
+        t.equal(true, ES.IsInteger(-0), '-0 is integer');
+        const notInts = v.nonNumbers.concat(v.nonIntegerNumbers, [
+            Infinity,
+            -Infinity,
+            NaN,
+            [],
+            new Date(),
+        ]);
+        forEach(notInts, notInt => {
+            t.equal(
+                false,
+                ES.IsInteger(notInt),
+                `${debug(notInt)} is not integer`
+            );
+        });
+        t.equal(
+            false,
+            ES.IsInteger(v.uncoercibleObject),
+            'uncoercibleObject is not integer'
+        );
+        t.end();
+    });
+
+    test('IsExtensible', t => {
+        forEach(v.objects, object => {
+            t.equal(
+                true,
+                ES.IsExtensible(object),
+                `${debug(object)} object is extensible`
+            );
+        });
+        forEach(v.primitives, primitive => {
+            t.equal(
+                false,
+                ES.IsExtensible(primitive),
+                `${debug(primitive)} is not extensible`
+            );
+        });
+        if (Object.preventExtensions) {
+            t.equal(
+                false,
+                ES.IsExtensible(Object.preventExtensions({})),
+                'object with extensions prevented is not extensible'
+            );
+        }
+        t.end();
+    });
+
+    test('CanonicalNumericIndexString', t => {
+        const throwsOnNonString = function(notString) {
+            t.throws(
+                () => ES.CanonicalNumericIndexString(notString),
+                TypeError,
+                `${debug(notString)} is not a string`
+            );
+        };
+        forEach(v.objects.concat(v.numbers), throwsOnNonString);
+        t.ok(is(-0, ES.CanonicalNumericIndexString('-0')), '"-0" returns -0');
+        for (let i = -50; i < 50; i += 10) {
+            t.equal(
+                i,
+                ES.CanonicalNumericIndexString(String(i)),
+                `"${i}" returns ${i}`
+            );
+            t.equal(
+                undefined,
+                ES.CanonicalNumericIndexString(`${String(i)}a`),
+                `"${i}a" returns undefined`
+            );
+        }
+        t.end();
+    });
+
+    test('IsConstructor', t => {
+        t.equal(true, ES.IsConstructor(() => {}), 'function is constructor');
+        t.equal(false, ES.IsConstructor(/a/g), 'regex is not constructor');
+        forEach(v.objects, object => {
+            t.equal(
+                false,
+                ES.IsConstructor(object),
+                `${object} object is not constructor`
+            );
+        });
+
+        try {
+            const foo = Function('return class Foo {}')(); // eslint-disable-line no-new-func
+            t.equal(ES.IsConstructor(foo), true, 'class is constructor');
+        } catch (e) {
+            t.comment('SKIP: class syntax not supported.');
+        }
+        t.end();
+    });
+
+    test('Call', t => {
+        const receiver = {};
+        const notFuncs = v.objects
+            .concat(v.primitives)
+            .concat([/a/g, new RegExp('a', 'g')]);
+        t.plan(notFuncs.length + 4);
+        const throwsIfNotCallable = function(notFunc) {
+            t.throws(
+                () => ES.Call(notFunc, receiver),
+                TypeError,
+                `${debug(notFunc)} (${typeof notFunc}) is not callable`
+            );
+        };
+        forEach(notFuncs, throwsIfNotCallable);
+        ES.Call(
+            function(a, b) {
+                t.equal(this, receiver, 'context matches expected');
+                t.deepEqual([a, b], [1, 2], 'named args are correct');
+                t.equal(arguments.length, 3, 'extra argument was passed');
+                t.equal(arguments[2], 3, 'extra argument was correct');
+            },
+            receiver,
+            [1, 2, 3]
+        );
+        t.end();
+    });
+
+    test('GetV', t => {
+        t.throws(
+            () => ES.GetV({ 7: 7 }, 7),
+            TypeError,
+            'Throws a TypeError if `P` is not a property key'
+        );
+        const obj = { a() {} };
+        t.equal(ES.GetV(obj, 'a'), obj.a, 'returns property if it exists');
+        t.equal(
+            ES.GetV(obj, 'b'),
+            undefined,
+            'returns undefiend if property does not exist'
+        );
+        t.end();
+    });
+
+    test('GetMethod', t => {
+        t.throws(
+            () => ES.GetMethod({ 7: 7 }, 7),
+            TypeError,
+            'Throws a TypeError if `P` is not a property key'
+        );
+        t.equal(
+            ES.GetMethod({}, 'a'),
+            undefined,
+            'returns undefined in property is undefined'
+        );
+        t.equal(
+            ES.GetMethod({ a: null }, 'a'),
+            undefined,
+            'returns undefined if property is null'
+        );
+        t.equal(
+            ES.GetMethod({ a: undefined }, 'a'),
+            undefined,
+            'returns undefined if property is undefined'
+        );
+        const obj = { a() {} };
+        t.throws(
+            () => {
+                ES.GetMethod({ a: 'b' }, 'a');
+            },
+            TypeError,
+            'throws TypeError if property exists and is not callable'
+        );
+        t.equal(
+            ES.GetMethod(obj, 'a'),
+            obj.a,
+            'returns property if it is callable'
+        );
+        t.end();
+    });
+
+    test('Get', t => {
+        t.throws(
+            () => ES.Get('a', 'a'),
+            TypeError,
+            'Throws a TypeError if `O` is not an Object'
+        );
+        t.throws(
+            () => ES.Get({ 7: 7 }, 7),
+            TypeError,
+            'Throws a TypeError if `P` is not a property key'
+        );
+
+        const value = {};
+        t.test('Symbols', { skip: !v.hasSymbols }, st => {
+            const sym = Symbol('sym');
+            const obj = {};
+            obj[sym] = value;
+            st.equal(
+                ES.Get(obj, sym),
+                value,
+                'returns property `P` if it exists on object `O`'
+            );
+            st.end();
+        });
+        t.equal(
+            ES.Get({ a: value }, 'a'),
+            value,
+            'returns property `P` if it exists on object `O`'
+        );
+        t.end();
+    });
+
+    test('Type', { skip: !v.hasSymbols }, t => {
+        t.equal(
+            ES.Type(Symbol.iterator),
+            'Symbol',
+            'Type(Symbol.iterator) is Symbol'
+        );
+        t.end();
+    });
+
+    test('SpeciesConstructor', t => {
+        t.throws(() => {
+            ES.SpeciesConstructor(null);
+        }, TypeError);
+        t.throws(() => {
+            ES.SpeciesConstructor(undefined);
+        }, TypeError);
+
+        const defaultConstructor = function Foo() {};
+
+        t.equal(
+            ES.SpeciesConstructor(
+                { constructor: undefined },
+                defaultConstructor
+            ),
+            defaultConstructor,
+            'undefined constructor returns defaultConstructor'
+        );
+
+        t.throws(
+            () =>
+                ES.SpeciesConstructor(
+                    { constructor: null },
+                    defaultConstructor
+                ),
+            TypeError,
+            'non-undefined non-object constructor throws'
+        );
+
+        t.test('with Symbol.species', { skip: !hasSpecies }, st => {
+            const Bar = function Bar() {};
+            Bar[Symbol.species] = null;
+
+            st.equal(
+                ES.SpeciesConstructor(new Bar(), defaultConstructor),
+                defaultConstructor,
+                'undefined/null Symbol.species returns default constructor'
+            );
+
+            const Baz = function Baz() {};
+            Baz[Symbol.species] = Bar;
+            st.equal(
+                ES.SpeciesConstructor(new Baz(), defaultConstructor),
+                Bar,
+                'returns Symbol.species constructor value'
+            );
+
+            Baz[Symbol.species] = {};
+            st.throws(
+                () => {
+                    ES.SpeciesConstructor(new Baz(), defaultConstructor);
+                },
+                TypeError,
+                'throws when non-constructor non-null non-undefined species value found'
+            );
+
+            st.end();
+        });
+
+        t.end();
+    });
+
+    const bothDescriptor = function() {
+        return { '[[Get]]'() {}, '[[Value]]': true };
+    };
+    const accessorDescriptor = function() {
+        return {
+            '[[Get]]'() {},
+            '[[Enumerable]]': true,
+            '[[Configurable]]': true,
+        };
+    };
+    const mutatorDescriptor = function() {
+        return {
+            '[[Set]]'() {},
+            '[[Enumerable]]': true,
+            '[[Configurable]]': true,
+        };
+    };
+    const dataDescriptor = function() {
+        return {
+            '[[Value]]': 42,
+            '[[Writable]]': false,
+        };
+    };
+    const genericDescriptor = function() {
+        return {
+            '[[Configurable]]': true,
+            '[[Enumerable]]': false,
+        };
+    };
+
+    test('IsPropertyDescriptor', t => {
+        forEach(v.nonUndefinedPrimitives, primitive => {
+            t.equal(
+                ES.IsPropertyDescriptor(primitive),
+                false,
+                `${debug(primitive)} is not a Property Descriptor`
+            );
+        });
+
+        t.equal(
+            ES.IsPropertyDescriptor({ invalid: true }),
+            false,
+            'invalid keys not allowed on a Property Descriptor'
+        );
+
+        t.equal(
+            ES.IsPropertyDescriptor({}),
+            true,
+            'empty object is an incomplete Property Descriptor'
+        );
+
+        t.equal(
+            ES.IsPropertyDescriptor(accessorDescriptor()),
+            true,
+            'accessor descriptor is a Property Descriptor'
+        );
+        t.equal(
+            ES.IsPropertyDescriptor(mutatorDescriptor()),
+            true,
+            'mutator descriptor is a Property Descriptor'
+        );
+        t.equal(
+            ES.IsPropertyDescriptor(dataDescriptor()),
+            true,
+            'data descriptor is a Property Descriptor'
+        );
+        t.equal(
+            ES.IsPropertyDescriptor(genericDescriptor()),
+            true,
+            'generic descriptor is a Property Descriptor'
+        );
+
+        t.throws(
+            () => {
+                ES.IsPropertyDescriptor(bothDescriptor());
+            },
+            TypeError,
+            'a Property Descriptor can not be both a Data and an Accessor Descriptor'
+        );
+
+        t.end();
+    });
+
+    test('IsAccessorDescriptor', t => {
+        forEach(v.nonUndefinedPrimitives, primitive => {
+            t.throws(
+                () => {
+                    ES.IsAccessorDescriptor(primitive);
+                },
+                TypeError,
+                `${debug(primitive)} is not a Property Descriptor`
+            );
+        });
+
+        t.equal(
+            ES.IsAccessorDescriptor(),
+            false,
+            'no value is not an Accessor Descriptor'
+        );
+        t.equal(
+            ES.IsAccessorDescriptor(undefined),
+            false,
+            'undefined value is not an Accessor Descriptor'
+        );
+
+        t.equal(
+            ES.IsAccessorDescriptor(accessorDescriptor()),
+            true,
+            'accessor descriptor is an Accessor Descriptor'
+        );
+        t.equal(
+            ES.IsAccessorDescriptor(mutatorDescriptor()),
+            true,
+            'mutator descriptor is an Accessor Descriptor'
+        );
+        t.equal(
+            ES.IsAccessorDescriptor(dataDescriptor()),
+            false,
+            'data descriptor is not an Accessor Descriptor'
+        );
+        t.equal(
+            ES.IsAccessorDescriptor(genericDescriptor()),
+            false,
+            'generic descriptor is not an Accessor Descriptor'
+        );
+
+        t.end();
+    });
+
+    test('IsDataDescriptor', t => {
+        forEach(v.nonUndefinedPrimitives, primitive => {
+            t.throws(
+                () => {
+                    ES.IsDataDescriptor(primitive);
+                },
+                TypeError,
+                `${debug(primitive)} is not a Property Descriptor`
+            );
+        });
+
+        t.equal(
+            ES.IsDataDescriptor(),
+            false,
+            'no value is not a Data Descriptor'
+        );
+        t.equal(
+            ES.IsDataDescriptor(undefined),
+            false,
+            'undefined value is not a Data Descriptor'
+        );
+
+        t.equal(
+            ES.IsDataDescriptor(accessorDescriptor()),
+            false,
+            'accessor descriptor is not a Data Descriptor'
+        );
+        t.equal(
+            ES.IsDataDescriptor(mutatorDescriptor()),
+            false,
+            'mutator descriptor is not a Data Descriptor'
+        );
+        t.equal(
+            ES.IsDataDescriptor(dataDescriptor()),
+            true,
+            'data descriptor is a Data Descriptor'
+        );
+        t.equal(
+            ES.IsDataDescriptor(genericDescriptor()),
+            false,
+            'generic descriptor is not a Data Descriptor'
+        );
+
+        t.end();
+    });
+
+    test('IsGenericDescriptor', t => {
+        forEach(v.nonUndefinedPrimitives, primitive => {
+            t.throws(
+                () => {
+                    ES.IsGenericDescriptor(primitive);
+                },
+                TypeError,
+                `${debug(primitive)} is not a Property Descriptor`
+            );
+        });
+
+        t.equal(
+            ES.IsGenericDescriptor(),
+            false,
+            'no value is not a Data Descriptor'
+        );
+        t.equal(
+            ES.IsGenericDescriptor(undefined),
+            false,
+            'undefined value is not a Data Descriptor'
+        );
+
+        t.equal(
+            ES.IsGenericDescriptor(accessorDescriptor()),
+            false,
+            'accessor descriptor is not a generic Descriptor'
+        );
+        t.equal(
+            ES.IsGenericDescriptor(mutatorDescriptor()),
+            false,
+            'mutator descriptor is not a generic Descriptor'
+        );
+        t.equal(
+            ES.IsGenericDescriptor(dataDescriptor()),
+            false,
+            'data descriptor is not a generic Descriptor'
+        );
+
+        t.equal(
+            ES.IsGenericDescriptor(genericDescriptor()),
+            true,
+            'generic descriptor is a generic Descriptor'
+        );
+
+        t.end();
+    });
+
+    test('FromPropertyDescriptor', t => {
+        t.equal(
+            ES.FromPropertyDescriptor(),
+            undefined,
+            'no value begets undefined'
+        );
+        t.equal(
+            ES.FromPropertyDescriptor(undefined),
+            undefined,
+            'undefined value begets undefined'
+        );
+
+        forEach(v.nonUndefinedPrimitives, primitive => {
+            t.throws(
+                () => {
+                    ES.FromPropertyDescriptor(primitive);
+                },
+                TypeError,
+                `${debug(primitive)} is not a Property Descriptor`
+            );
+        });
+
+        const accessor = accessorDescriptor();
+        t.deepEqual(ES.FromPropertyDescriptor(accessor), {
+            get: accessor['[[Get]]'],
+            set: accessor['[[Set]]'],
+            enumerable: !!accessor['[[Enumerable]]'],
+            configurable: !!accessor['[[Configurable]]'],
+        });
+
+        const mutator = mutatorDescriptor();
+        t.deepEqual(ES.FromPropertyDescriptor(mutator), {
+            get: mutator['[[Get]]'],
+            set: mutator['[[Set]]'],
+            enumerable: !!mutator['[[Enumerable]]'],
+            configurable: !!mutator['[[Configurable]]'],
+        });
+        const data = dataDescriptor();
+        t.deepEqual(ES.FromPropertyDescriptor(data), {
+            value: data['[[Value]]'],
+            writable: data['[[Writable]]'],
+            enumerable: !!data['[[Enumerable]]'],
+            configurable: !!data['[[Configurable]]'],
+        });
+
+        t.throws(
+            () => {
+                ES.FromPropertyDescriptor(genericDescriptor());
+            },
+            TypeError,
+            'a complete Property Descriptor is required'
+        );
+
+        t.end();
+    });
+
+    test('ToPropertyDescriptor', t => {
+        forEach(v.nonUndefinedPrimitives, primitive => {
+            t.throws(
+                () => {
+                    ES.ToPropertyDescriptor(primitive);
+                },
+                TypeError,
+                `${debug(primitive)} is not an Object`
+            );
+        });
+
+        const accessor = accessorDescriptor();
+        t.deepEqual(
+            ES.ToPropertyDescriptor({
+                get: accessor['[[Get]]'],
+                enumerable: !!accessor['[[Enumerable]]'],
+                configurable: !!accessor['[[Configurable]]'],
+            }),
+            accessor
+        );
+
+        const mutator = mutatorDescriptor();
+        t.deepEqual(
+            ES.ToPropertyDescriptor({
+                set: mutator['[[Set]]'],
+                enumerable: !!mutator['[[Enumerable]]'],
+                configurable: !!mutator['[[Configurable]]'],
+            }),
+            mutator
+        );
+
+        const data = dataDescriptor();
+        t.deepEqual(
+            ES.ToPropertyDescriptor({
+                value: data['[[Value]]'],
+                writable: data['[[Writable]]'],
+                configurable: !!data['[[Configurable]]'],
+            }),
+            assign(data, { '[[Configurable]]': false })
+        );
+
+        const both = bothDescriptor();
+        t.throws(
+            () => {
+                ES.FromPropertyDescriptor({
+                    get: both['[[Get]]'],
+                    value: both['[[Value]]'],
+                });
+            },
+            TypeError,
+            'data and accessor descriptors are mutually exclusive'
+        );
+
+        t.end();
+    });
+
+    test('CompletePropertyDescriptor', t => {
+        forEach(v.nonUndefinedPrimitives, primitive => {
+            t.throws(
+                () => {
+                    ES.CompletePropertyDescriptor(primitive);
+                },
+                TypeError,
+                `${debug(primitive)} is not a Property Descriptor`
+            );
+        });
+
+        const generic = genericDescriptor();
+        t.deepEqual(
+            ES.CompletePropertyDescriptor(generic),
+            {
+                '[[Configurable]]': !!generic['[[Configurable]]'],
+                '[[Enumerable]]': !!generic['[[Enumerable]]'],
+                '[[Value]]': undefined,
+                '[[Writable]]': false,
+            },
+            'completes a Generic Descriptor'
+        );
+
+        const data = dataDescriptor();
+        t.deepEqual(
+            ES.CompletePropertyDescriptor(data),
+            {
+                '[[Configurable]]': !!data['[[Configurable]]'],
+                '[[Enumerable]]': false,
+                '[[Value]]': data['[[Value]]'],
+                '[[Writable]]': !!data['[[Writable]]'],
+            },
+            'completes a Data Descriptor'
+        );
+
+        const accessor = accessorDescriptor();
+        t.deepEqual(
+            ES.CompletePropertyDescriptor(accessor),
+            {
+                '[[Get]]': accessor['[[Get]]'],
+                '[[Enumerable]]': !!accessor['[[Enumerable]]'],
+                '[[Configurable]]': !!accessor['[[Configurable]]'],
+                '[[Set]]': undefined,
+            },
+            'completes an Accessor Descriptor'
+        );
+
+        const mutator = mutatorDescriptor();
+        t.deepEqual(
+            ES.CompletePropertyDescriptor(mutator),
+            {
+                '[[Set]]': mutator['[[Set]]'],
+                '[[Enumerable]]': !!mutator['[[Enumerable]]'],
+                '[[Configurable]]': !!mutator['[[Configurable]]'],
+                '[[Get]]': undefined,
+            },
+            'completes a mutator Descriptor'
+        );
+
+        t.throws(
+            () => {
+                ES.CompletePropertyDescriptor(bothDescriptor());
+            },
+            TypeError,
+            'data and accessor descriptors are mutually exclusive'
+        );
+
+        t.end();
+    });
+
+    test('Set', t => {
+        forEach(v.primitives, primitive => {
+            t.throws(
+                () => {
+                    ES.Set(primitive, '', null, false);
+                },
+                TypeError,
+                `${debug(primitive)} is not an Object`
+            );
+        });
+
+        forEach(v.nonPropertyKeys, nonKey => {
+            t.throws(
+                () => {
+                    ES.Set({}, nonKey, null, false);
+                },
+                TypeError,
+                `${debug(nonKey)} is not a Property Key`
+            );
+        });
+
+        forEach(v.nonBooleans, nonBoolean => {
+            t.throws(
+                () => {
+                    ES.Set({}, '', null, nonBoolean);
+                },
+                TypeError,
+                `${debug(nonBoolean)} is not a Boolean`
+            );
+        });
+
+        const o = {};
+        const value = {};
+        ES.Set(o, 'key', value, true);
+        t.deepEqual(o, { key: value }, 'key is set');
+
+        t.test('nonwritable', { skip: !Object.defineProperty }, st => {
+            const obj = { a: value };
+            Object.defineProperty(obj, 'a', { writable: false });
+
+            st.throws(
+                () => {
+                    ES.Set(obj, 'a', value, true);
+                },
+                TypeError,
+                'can not Set nonwritable property'
+            );
+
+            st.doesNotThrow(() => {
+                ES.Set(obj, 'a', value, false);
+            }, 'setting Throw to false prevents an exception');
+
+            st.end();
+        });
+
+        t.test('nonconfigurable', { skip: !Object.defineProperty }, st => {
+            const obj = { a: value };
+            Object.defineProperty(obj, 'a', { configurable: false });
+
+            ES.Set(obj, 'a', value, true);
+            st.deepEqual(obj, { a: value }, 'key is set');
+
+            st.end();
+        });
+
+        t.end();
+    });
+
+    test('HasOwnProperty', t => {
+        forEach(v.primitives, primitive => {
+            t.throws(
+                () => {
+                    ES.HasOwnProperty(primitive, 'key');
+                },
+                TypeError,
+                `${debug(primitive)} is not an Object`
+            );
+        });
+
+        forEach(v.nonPropertyKeys, nonKey => {
+            t.throws(
+                () => {
+                    ES.HasOwnProperty({}, nonKey);
+                },
+                TypeError,
+                `${debug(nonKey)} is not a Property Key`
+            );
+        });
+
+        t.equal(
+            ES.HasOwnProperty({}, 'toString'),
+            false,
+            'inherited properties are not own'
+        );
+        t.equal(
+            ES.HasOwnProperty({ toString: 1 }, 'toString'),
+            true,
+            'shadowed inherited own properties are own'
+        );
+        t.equal(
+            ES.HasOwnProperty({ a: 1 }, 'a'),
+            true,
+            'own properties are own'
+        );
+
+        t.end();
+    });
+
+    test('HasProperty', t => {
+        forEach(v.primitives, primitive => {
+            t.throws(
+                () => {
+                    ES.HasProperty(primitive, 'key');
+                },
+                TypeError,
+                `${debug(primitive)} is not an Object`
+            );
+        });
+
+        forEach(v.nonPropertyKeys, nonKey => {
+            t.throws(
+                () => {
+                    ES.HasProperty({}, nonKey);
+                },
+                TypeError,
+                `${debug(nonKey)} is not a Property Key`
+            );
+        });
+
+        t.equal(
+            ES.HasProperty({}, 'nope'),
+            false,
+            'object does not have nonexistent properties'
+        );
+        t.equal(
+            ES.HasProperty({}, 'toString'),
+            true,
+            'object has inherited properties'
+        );
+        t.equal(
+            ES.HasProperty({ toString: 1 }, 'toString'),
+            true,
+            'object has shadowed inherited own properties'
+        );
+        t.equal(
+            ES.HasProperty({ a: 1 }, 'a'),
+            true,
+            'object has own properties'
+        );
+
+        t.end();
+    });
+
+    test('IsConcatSpreadable', t => {
+        forEach(v.primitives, primitive => {
+            t.equal(
+                ES.IsConcatSpreadable(primitive),
+                false,
+                `${debug(primitive)} is not an Object`
+            );
+        });
+
+        const hasSymbolConcatSpreadable =
+            v.hasSymbols && Symbol.isConcatSpreadable;
+        t.test(
+            'Symbol.isConcatSpreadable',
+            { skip: !hasSymbolConcatSpreadable },
+            st => {
+                forEach(v.falsies, falsy => {
+                    const obj = {};
+                    obj[Symbol.isConcatSpreadable] = falsy;
+                    st.equal(
+                        ES.IsConcatSpreadable(obj),
+                        false,
+                        `an object with ${debug(
+                            falsy
+                        )} as Symbol.isConcatSpreadable is not concat spreadable`
+                    );
+                });
+
+                forEach(v.truthies, truthy => {
+                    const obj = {};
+                    obj[Symbol.isConcatSpreadable] = truthy;
+                    st.equal(
+                        ES.IsConcatSpreadable(obj),
+                        true,
+                        `an object with ${debug(
+                            truthy
+                        )} as Symbol.isConcatSpreadable is concat spreadable`
+                    );
+                });
+
+                st.end();
+            }
+        );
+
+        forEach(v.objects, object => {
+            t.equal(
+                ES.IsConcatSpreadable(object),
+                false,
+                'non-array without Symbol.isConcatSpreadable is not concat spreadable'
+            );
+        });
+
+        t.equal(
+            ES.IsConcatSpreadable([]),
+            true,
+            'arrays are concat spreadable'
+        );
+
+        t.end();
+    });
+
+    test('Invoke', t => {
+        forEach(v.nonPropertyKeys, nonKey => {
+            t.throws(
+                () => {
+                    ES.Invoke({}, nonKey);
+                },
+                TypeError,
+                `${debug(nonKey)} is not a Property Key`
+            );
+        });
+
+        t.throws(
+            () => {
+                ES.Invoke({ o: false }, 'o');
+            },
+            TypeError,
+            'fails on a non-function'
+        );
+
+        t.test('invoked callback', st => {
+            const aValue = {};
+            const bValue = {};
+            const obj = {
+                f(a) {
+                    st.equal(arguments.length, 2, '2 args passed');
+                    st.equal(a, aValue, 'first arg is correct');
+                    st.equal(arguments[1], bValue, 'second arg is correct');
+                },
+            };
+            st.plan(3);
+            ES.Invoke(obj, 'f', aValue, bValue);
+        });
+
+        t.end();
+    });
+
+    test('CreateIterResultObject', t => {
+        forEach(v.nonBooleans, nonBoolean => {
+            t.throws(
+                () => {
+                    ES.CreateIterResultObject({}, nonBoolean);
+                },
+                TypeError,
+                `"done" argument must be a boolean; ${debug(nonBoolean)} is not`
+            );
+        });
+
+        const value = {};
+        t.deepEqual(
+            ES.CreateIterResultObject(value, true),
+            {
+                value,
+                done: true,
+            },
+            'creates a "done" iteration result'
+        );
+        t.deepEqual(
+            ES.CreateIterResultObject(value, false),
+            {
+                value,
+                done: false,
+            },
+            'creates a "not done" iteration result'
+        );
+
+        t.end();
+    });
+
+    test('RegExpExec', t => {
+        forEach(v.primitives, primitive => {
+            t.throws(
+                () => {
+                    ES.RegExpExec(primitive);
+                },
+                TypeError,
+                `"R" argument must be an object; ${debug(primitive)} is not`
+            );
+        });
+
+        forEach(v.nonStrings, nonString => {
+            t.throws(
+                () => {
+                    ES.RegExpExec({}, nonString);
+                },
+                TypeError,
+                `"S" argument must be a String; ${debug(nonString)} is not`
+            );
+        });
+
+        t.test('gets and calls a callable "exec"', st => {
+            const str = '123';
+            var o = {
+                exec(S) {
+                    st.equal(this, o, '"exec" receiver is R');
+                    st.equal(S, str, '"exec" argument is S');
+
+                    return null;
+                },
+            };
+            st.plan(2);
+            ES.RegExpExec(o, str);
+            st.end();
+        });
+
+        t.test(
+            'throws if a callable "exec" returns a non-null non-object',
+            st => {
+                const str = '123';
+                st.plan(v.nonNullPrimitives.length);
+                forEach(v.nonNullPrimitives, nonNullPrimitive => {
+                    st.throws(
+                        () => {
+                            ES.RegExpExec(
+                                {
+                                    exec() {
+                                        return nonNullPrimitive;
+                                    },
+                                },
+                                str
+                            );
+                        },
+                        TypeError,
+                        `"exec" method must return \`null\` or an Object; ${debug(
+                            nonNullPrimitive
+                        )} is not`
+                    );
+                });
+                st.end();
+            }
+        );
+
+        t.test('actual regex that should match against a string', st => {
+            const S = 'aabc';
+            const R = /a/g;
+            const match1 = ES.RegExpExec(R, S);
+            const match2 = ES.RegExpExec(R, S);
+            const match3 = ES.RegExpExec(R, S);
+            st.deepEqual(
+                match1,
+                assign(['a'], { index: 0, input: S }),
+                'match object 1 is as expected'
+            );
+            st.deepEqual(
+                match2,
+                assign(['a'], { index: 1, input: S }),
+                'match object 2 is as expected'
+            );
+            st.equal(match3, null, 'match 3 is null as expected');
+            st.end();
+        });
+
+        t.test(
+            'actual regex that should match against a string, with shadowed "exec"',
+            st => {
+                const S = 'aabc';
+                const R = /a/g;
+                R.exec = undefined;
+                const match1 = ES.RegExpExec(R, S);
+                const match2 = ES.RegExpExec(R, S);
+                const match3 = ES.RegExpExec(R, S);
+                st.deepEqual(
+                    match1,
+                    assign(['a'], { index: 0, input: S }),
+                    'match object 1 is as expected'
+                );
+                st.deepEqual(
+                    match2,
+                    assign(['a'], { index: 1, input: S }),
+                    'match object 2 is as expected'
+                );
+                st.equal(match3, null, 'match 3 is null as expected');
+                st.end();
+            }
+        );
+        t.end();
+    });
+
+    test('ArraySpeciesCreate', t => {
+        t.test('errors', st => {
+            const testNonNumber = function(nonNumber) {
+                st.throws(
+                    () => {
+                        ES.ArraySpeciesCreate([], nonNumber);
+                    },
+                    TypeError,
+                    `${debug(nonNumber)} is not a number`
+                );
+            };
+            forEach(v.nonNumbers, testNonNumber);
+
+            st.throws(
+                () => {
+                    ES.ArraySpeciesCreate([], -1);
+                },
+                TypeError,
+                '-1 is not >= 0'
+            );
+            st.throws(
+                () => {
+                    ES.ArraySpeciesCreate([], -Infinity);
+                },
+                TypeError,
+                '-Infinity is not >= 0'
+            );
+
+            const testNonIntegers = function(nonInteger) {
+                st.throws(
+                    () => {
+                        ES.ArraySpeciesCreate([], nonInteger);
+                    },
+                    TypeError,
+                    `${debug(nonInteger)} is not an integer`
+                );
+            };
+            forEach(v.nonIntegerNumbers, testNonIntegers);
+
+            st.end();
+        });
+
+        t.test('works with a non-array', st => {
+            forEach(v.objects.concat(v.primitives), nonArray => {
+                const arr = ES.ArraySpeciesCreate(nonArray, 0);
+                st.ok(ES.IsArray(arr), 'is an array');
+                st.equal(arr.length, 0, 'length is correct');
+                st.equal(arr.constructor, Array, 'constructor is correct');
+            });
+
+            st.end();
+        });
+
+        t.test('works with a normal array', st => {
+            const len = 2;
+            const orig = [1, 2, 3];
+            const arr = ES.ArraySpeciesCreate(orig, len);
+
+            st.ok(ES.IsArray(arr), 'is an array');
+            st.equal(arr.length, len, 'length is correct');
+            st.equal(
+                arr.constructor,
+                orig.constructor,
+                'constructor is correct'
+            );
+
+            st.end();
+        });
+
+        t.test('-0 length produces +0 length', st => {
+            const len = -0;
+            st.ok(is(len, -0), '-0 is negative zero');
+            st.notOk(is(len, 0), '-0 is not positive zero');
+
+            const orig = [1, 2, 3];
+            const arr = ES.ArraySpeciesCreate(orig, len);
+
+            st.equal(ES.IsArray(arr), true);
+            st.ok(is(arr.length, 0));
+            st.equal(arr.constructor, orig.constructor);
+
+            st.end();
+        });
+
+        t.test('works with species construtor', { skip: !hasSpecies }, st => {
+            const sentinel = {};
+            const Foo = function Foo(len) {
+                this.length = len;
+                this.sentinel = sentinel;
+            };
+            const Bar = getArraySubclassWithSpeciesConstructor(Foo);
+            const bar = new Bar();
+
+            t.equal(ES.IsArray(bar), true, 'Bar instance is an array');
+
+            const arr = ES.ArraySpeciesCreate(bar, 3);
+            st.equal(arr.constructor, Foo, 'result used species constructor');
+            st.equal(arr.length, 3, 'length property is correct');
+            st.equal(arr.sentinel, sentinel, 'Foo constructor was exercised');
+
+            st.end();
+        });
+
+        t.test(
+            'works with null species constructor',
+            { skip: !hasSpecies },
+            st => {
+                const Bar = getArraySubclassWithSpeciesConstructor(null);
+                const bar = new Bar();
+
+                t.equal(ES.IsArray(bar), true, 'Bar instance is an array');
+
+                const arr = ES.ArraySpeciesCreate(bar, 3);
+                st.equal(
+                    arr.constructor,
+                    Array,
+                    'result used default constructor'
+                );
+                st.equal(arr.length, 3, 'length property is correct');
+
+                st.end();
+            }
+        );
+
+        t.test(
+            'works with undefined species constructor',
+            { skip: !hasSpecies },
+            st => {
+                const Bar = getArraySubclassWithSpeciesConstructor();
+                const bar = new Bar();
+
+                t.equal(ES.IsArray(bar), true, 'Bar instance is an array');
+
+                const arr = ES.ArraySpeciesCreate(bar, 3);
+                st.equal(
+                    arr.constructor,
+                    Array,
+                    'result used default constructor'
+                );
+                st.equal(arr.length, 3, 'length property is correct');
+
+                st.end();
+            }
+        );
+
+        t.test(
+            'throws with object non-construtor species constructor',
+            { skip: !hasSpecies },
+            st => {
+                forEach(v.objects, obj => {
+                    const Bar = getArraySubclassWithSpeciesConstructor(obj);
+                    const bar = new Bar();
+
+                    st.equal(ES.IsArray(bar), true, 'Bar instance is an array');
+
+                    st.throws(
+                        () => {
+                            ES.ArraySpeciesCreate(bar, 3);
+                        },
+                        TypeError,
+                        `${debug(obj)} is not a constructor`
+                    );
+                });
+
+                st.end();
+            }
+        );
+
+        t.end();
+    });
+
+    test('CreateDataProperty', t => {
+        forEach(v.primitives, primitive => {
+            t.throws(
+                () => {
+                    ES.CreateDataProperty(primitive);
+                },
+                TypeError,
+                `${debug(primitive)} is not an object`
+            );
+        });
+
+        forEach(v.nonPropertyKeys, nonPropertyKey => {
+            t.throws(
+                () => {
+                    ES.CreateDataProperty({}, nonPropertyKey);
+                },
+                TypeError,
+                `${debug(nonPropertyKey)} is not a property key`
+            );
+        });
+
+        const sentinel = {};
+        forEach(v.propertyKeys, propertyKey => {
+            const obj = {};
+            const status = ES.CreateDataProperty(obj, propertyKey, sentinel);
+            t.equal(status, true, 'status is true');
+            t.equal(
+                obj[propertyKey],
+                sentinel,
+                `${debug(sentinel)} is installed on "${debug(
+                    propertyKey
+                )}" on the object`
+            );
+
+            if (typeof Object.defineProperty === 'function') {
+                const nonWritable = Object.defineProperty({}, propertyKey, {
+                    configurable: true,
+                    writable: false,
+                });
+
+                const nonWritableStatus = ES.CreateDataProperty(
+                    nonWritable,
+                    propertyKey,
+                    sentinel
+                );
+                t.equal(
+                    nonWritableStatus,
+                    false,
+                    'create data property failed'
+                );
+                t.notEqual(
+                    nonWritable[propertyKey],
+                    sentinel,
+                    `${debug(sentinel)} is not installed on "${debug(
+                        propertyKey
+                    )}" on the object when key is nonwritable`
+                );
+
+                const nonConfigurable = Object.defineProperty({}, propertyKey, {
+                    configurable: false,
+                    writable: true,
+                });
+
+                const nonConfigurableStatus = ES.CreateDataProperty(
+                    nonConfigurable,
+                    propertyKey,
+                    sentinel
+                );
+                t.equal(
+                    nonConfigurableStatus,
+                    false,
+                    'create data property failed'
+                );
+                t.notEqual(
+                    nonConfigurable[propertyKey],
+                    sentinel,
+                    `${debug(sentinel)} is not installed on "${debug(
+                        propertyKey
+                    )}" on the object when key is nonconfigurable`
+                );
+            }
+        });
+
+        t.end();
+    });
+
+    test('CreateDataPropertyOrThrow', t => {
+        forEach(v.primitives, primitive => {
+            t.throws(
+                () => {
+                    ES.CreateDataPropertyOrThrow(primitive);
+                },
+                TypeError,
+                `${debug(primitive)} is not an object`
+            );
+        });
+
+        forEach(v.nonPropertyKeys, nonPropertyKey => {
+            t.throws(
+                () => {
+                    ES.CreateDataPropertyOrThrow({}, nonPropertyKey);
+                },
+                TypeError,
+                `${debug(nonPropertyKey)} is not a property key`
+            );
+        });
+
+        const sentinel = {};
+        forEach(v.propertyKeys, propertyKey => {
+            const obj = {};
+            const status = ES.CreateDataPropertyOrThrow(
+                obj,
+                propertyKey,
+                sentinel
+            );
+            t.equal(status, true, 'status is true');
+            t.equal(
+                obj[propertyKey],
+                sentinel,
+                `${debug(sentinel)} is installed on "${debug(
+                    propertyKey
+                )}" on the object`
+            );
+
+            if (typeof Object.preventExtensions === 'function') {
+                const notExtensible = {};
+                Object.preventExtensions(notExtensible);
+
+                t.throws(
+                    () => {
+                        ES.CreateDataPropertyOrThrow(
+                            notExtensible,
+                            propertyKey,
+                            sentinel
+                        );
+                    },
+                    TypeError,
+                    `can not install ${debug(
+                        propertyKey
+                    )} on non-extensible object`
+                );
+                t.notEqual(
+                    notExtensible[propertyKey],
+                    sentinel,
+                    `${debug(sentinel)} is not installed on "${debug(
+                        propertyKey
+                    )}" on the object`
+                );
+            }
+        });
+
+        t.end();
+    });
+
+    test('AdvanceStringIndex', t => {
+        forEach(v.nonStrings, nonString => {
+            t.throws(
+                () => {
+                    ES.AdvanceStringIndex(nonString);
+                },
+                TypeError,
+                `"S" argument must be a String; ${debug(nonString)} is not`
+            );
+        });
+
+        forEach(v.nonIntegerNumbers, nonInteger => {
+            t.throws(
+                () => {
+                    ES.AdvanceStringIndex('', nonInteger, false);
+                },
+                TypeError,
+                `"index" argument must be an integer; ${debug(
+                    nonInteger
+                )} is not`
+            );
+        });
+        forEach([-1, -42], negative => {
+            t.throws(
+                () => {
+                    ES.AdvanceStringIndex('', negative, false);
+                },
+                RangeError,
+                `"index" argument must be a non-negative integer; ${debug(
+                    negative
+                )} is not`
+            );
+        });
+        t.throws(
+            () => {
+                ES.AdvanceStringIndex('', MAX_SAFE_INTEGER + 1, false);
+            },
+            RangeError,
+            'too large integers throw'
+        );
+
+        forEach(v.nonBooleans, nonBoolean => {
+            t.throws(
+                () => {
+                    ES.AdvanceStringIndex('', 0, nonBoolean);
+                },
+                TypeError,
+                `"unicode" argument must be a Boolean; ${debug(
+                    nonBoolean
+                )} is not`
+            );
+        });
+
+        t.test('when unicode is false', st => {
+            st.equal(
+                ES.AdvanceStringIndex('', 0, false),
+                1,
+                'index is incremented by 1'
+            );
+            st.equal(
+                ES.AdvanceStringIndex('abc', 0, false),
+                1,
+                'index is incremented by 1'
+            );
+            st.equal(
+                ES.AdvanceStringIndex('', 3, false),
+                4,
+                'index is incremented by 1'
+            );
+            st.equal(
+                ES.AdvanceStringIndex('abc', 3, false),
+                4,
+                'index is incremented by 1'
+            );
+
+            st.test('when the index is within the string', s2t => {
+                s2t.equal(ES.AdvanceStringIndex('abc', 0, false), 1, '0 -> 1');
+                s2t.equal(ES.AdvanceStringIndex('abc', 1, false), 2, '1 -> 2');
+                s2t.equal(ES.AdvanceStringIndex('abc', 2, false), 3, '2 -> 3');
+                s2t.end();
+            });
+
+            st.end();
+        });
+
+        t.test('when unicode is true', st => {
+            st.test('when index + 1 >= length', s2t => {
+                t.equal(
+                    ES.AdvanceStringIndex('', 0, true),
+                    1,
+                    'index is incremented by 1'
+                );
+                t.equal(
+                    ES.AdvanceStringIndex('a', 0, true),
+                    1,
+                    'index is incremented by 1'
+                );
+                t.equal(
+                    ES.AdvanceStringIndex('a', 5, true),
+                    6,
+                    'index is incremented by 1'
+                );
+                s2t.end();
+            });
+
+            st.test('when the index is within the string', s2t => {
+                s2t.equal(ES.AdvanceStringIndex('abc', 0, true), 1, '0 -> 1');
+                s2t.equal(ES.AdvanceStringIndex('abc', 1, true), 2, '1 -> 2');
+                s2t.equal(ES.AdvanceStringIndex('abc', 2, true), 3, '2 -> 3');
+                s2t.end();
+            });
+
+            st.test('surrogate pairs', s2t => {
+                const lowestPair =
+                    String.fromCharCode('0xD800') +
+                    String.fromCharCode('0xDC00');
+                const highestPair =
+                    String.fromCharCode('0xDBFF') +
+                    String.fromCharCode('0xDFFF');
+                const poop =
+                    String.fromCharCode('0xD83D') +
+                    String.fromCharCode('0xDCA9');
+                s2t.equal(
+                    ES.AdvanceStringIndex(lowestPair, 0, true),
+                    2,
+                    'lowest surrogate pair, 0 -> 2'
+                );
+                s2t.equal(
+                    ES.AdvanceStringIndex(highestPair, 0, true),
+                    2,
+                    'highest surrogate pair, 0 -> 2'
+                );
+                s2t.equal(
+                    ES.AdvanceStringIndex(poop, 0, true),
+                    2,
+                    'poop, 0 -> 2'
+                );
+                s2t.end();
+            });
+
+            st.end();
+        });
+
+        t.end();
+    });
+};
+
+const es2016 = function ES2016(ES, ops, expectedMissing) {
+    es2015(ES, ops, expectedMissing);
+
+    test('SameValueNonNumber', t => {
+        const willThrow = [
+            [3, 4],
+            [NaN, 4],
+            [4, ''],
+            ['abc', true],
+            [{}, false],
+        ];
+        forEach(willThrow, nums => {
+            t.throws(
+                () => ES.SameValueNonNumber(...nums),
+                TypeError,
+                'value must be same type and non-number'
+            );
+        });
+
+        forEach(v.objects.concat(v.nonNumberPrimitives), val => {
+            t.equal(
+                val === val,
+                ES.SameValueNonNumber(val, val),
+                `${debug(val)} is SameValueNonNumber to itself`
+            );
+        });
+
+        t.end();
+    });
+};
+
+const es2017 = function E2017(ES, ops, expectedMissing) {
+    es2016(ES, ops, expectedMissing);
+
+    test('ToIndex', t => {
+        t.ok(is(ES.ToIndex(), 0), 'no value gives 0');
+        t.ok(is(ES.ToIndex(undefined), 0), 'undefined value gives 0');
+
+        t.throws(
+            () => {
+                ES.ToIndex(-1);
+            },
+            RangeError,
+            'negative numbers throw'
+        );
+
+        t.throws(
+            () => {
+                ES.ToIndex(MAX_SAFE_INTEGER + 1);
+            },
+            RangeError,
+            'too large numbers throw'
+        );
+
+        t.equal(ES.ToIndex(3), 3, 'numbers work');
+        t.equal(
+            ES.ToIndex(v.valueOfOnlyObject),
+            4,
+            'coercible objects are coerced'
+        );
+
+        t.end();
+    });
+};
+
+module.exports = {
+    es2015,
+    es2016,
+    es2017,
+};

--- a/test/mock/identical-implementation/node_modules/es-to-primitive/es5.js
+++ b/test/mock/identical-implementation/node_modules/es-to-primitive/es5.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const toStr = Object.prototype.toString;
+
+const isPrimitive = require('./helpers/isPrimitive');
+
+const isCallable = require('is-callable');
+
+// https://es5.github.io/#x8.12
+const ES5internalSlots = {
+    '[[DefaultValue]]'(O, hint) {
+        const actualHint =
+            hint || (toStr.call(O) === '[object Date]' ? String : Number);
+
+        if (actualHint === String || actualHint === Number) {
+            const methods =
+                actualHint === String
+                    ? ['toString', 'valueOf']
+                    : ['valueOf', 'toString'];
+            let value, i;
+            for (i = 0; i < methods.length; ++i) {
+                if (isCallable(O[methods[i]])) {
+                    value = O[methods[i]]();
+                    if (isPrimitive(value)) {
+                        return value;
+                    }
+                }
+            }
+            throw new TypeError('No default value');
+        }
+        throw new TypeError('invalid [[DefaultValue]] hint supplied');
+    },
+};
+
+// https://es5.github.io/#x9
+module.exports = function ToPrimitive(input, PreferredType) {
+    if (isPrimitive(input)) {
+        return input;
+    }
+    return ES5internalSlots['[[DefaultValue]]'](input, PreferredType);
+};

--- a/test/mock/identical-implementation/node_modules/es-to-primitive/es6.js
+++ b/test/mock/identical-implementation/node_modules/es-to-primitive/es6.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const hasSymbols =
+    typeof Symbol === 'function' && typeof Symbol.iterator === 'symbol';
+
+const isPrimitive = require('./helpers/isPrimitive');
+const isCallable = require('is-callable');
+const isDate = require('is-date-object');
+const isSymbol = require('is-symbol');
+
+const ordinaryToPrimitive = function OrdinaryToPrimitive(O, hint) {
+    if (typeof O === 'undefined' || O === null) {
+        throw new TypeError(`Cannot call method on ${O}`);
+    }
+    if (typeof hint !== 'string' || (hint !== 'number' && hint !== 'string')) {
+        throw new TypeError('hint must be "string" or "number"');
+    }
+    const methodNames =
+        hint === 'string' ? ['toString', 'valueOf'] : ['valueOf', 'toString'];
+    let method, result, i;
+    for (i = 0; i < methodNames.length; ++i) {
+        method = O[methodNames[i]];
+        if (isCallable(method)) {
+            result = method.call(O);
+            if (isPrimitive(result)) {
+                return result;
+            }
+        }
+    }
+    throw new TypeError('No default value');
+};
+
+const GetMethod = function GetMethod(O, P) {
+    const func = O[P];
+    if (func !== null && typeof func !== 'undefined') {
+        if (!isCallable(func)) {
+            throw new TypeError(
+                `${func} returned for property ${P} of object ${O} is not a function`
+            );
+        }
+        return func;
+    }
+};
+
+// http://www.ecma-international.org/ecma-262/6.0/#sec-toprimitive
+module.exports = function ToPrimitive(input, PreferredType) {
+    if (isPrimitive(input)) {
+        return input;
+    }
+    let hint = 'default';
+    if (arguments.length > 1) {
+        if (PreferredType === String) {
+            hint = 'string';
+        } else if (PreferredType === Number) {
+            hint = 'number';
+        }
+    }
+
+    let exoticToPrim;
+    if (hasSymbols) {
+        if (Symbol.toPrimitive) {
+            exoticToPrim = GetMethod(input, Symbol.toPrimitive);
+        } else if (isSymbol(input)) {
+            exoticToPrim = Symbol.prototype.valueOf;
+        }
+    }
+    if (typeof exoticToPrim !== 'undefined') {
+        const result = exoticToPrim.call(input, hint);
+        if (isPrimitive(result)) {
+            return result;
+        }
+        throw new TypeError('unable to convert exotic object to primitive');
+    }
+    if (hint === 'default' && (isDate(input) || isSymbol(input))) {
+        hint = 'string';
+    }
+    return ordinaryToPrimitive(input, hint === 'default' ? 'number' : hint);
+};

--- a/test/mock/identical-implementation/node_modules/es-to-primitive/helpers/isPrimitive.js
+++ b/test/mock/identical-implementation/node_modules/es-to-primitive/helpers/isPrimitive.js
@@ -1,0 +1,6 @@
+module.exports = function isPrimitive(value) {
+    return (
+        value === null ||
+        (typeof value !== 'function' && typeof value !== 'object')
+    );
+};

--- a/test/mock/identical-implementation/node_modules/es-to-primitive/index.js
+++ b/test/mock/identical-implementation/node_modules/es-to-primitive/index.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const ES5 = require('./es5');
+const ES6 = require('./es6');
+
+if (Object.defineProperty) {
+    Object.defineProperty(ES6, 'ES5', { enumerable: false, value: ES5 });
+    Object.defineProperty(ES6, 'ES6', { enumerable: false, value: ES6 });
+} else {
+    ES6.ES5 = ES5;
+    ES6.ES6 = ES6;
+}
+
+module.exports = ES6;

--- a/test/mock/identical-implementation/node_modules/es-to-primitive/package.json
+++ b/test/mock/identical-implementation/node_modules/es-to-primitive/package.json
@@ -1,0 +1,102 @@
+{
+  "_from": "es-to-primitive@^1.1.1",
+  "_id": "es-to-primitive@1.1.1",
+  "_inBundle": false,
+  "_integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+  "_location": "/es-to-primitive",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "range",
+    "registry": true,
+    "raw": "es-to-primitive@^1.1.1",
+    "name": "es-to-primitive",
+    "escapedName": "es-to-primitive",
+    "rawSpec": "^1.1.1",
+    "saveSpec": null,
+    "fetchSpec": "^1.1.1"
+  },
+  "_requiredBy": [
+    "/es-abstract"
+  ],
+  "_resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+  "_shasum": "45355248a88979034b6792e19bb81f2b7975dd0d",
+  "_spec": "es-to-primitive@^1.1.1",
+  "_where": "/Users/ricwalke/src/asset-pipe/asset-pipe-js-writer/test/mock/identical-implementation/node_modules/es-abstract",
+  "author": {
+    "name": "Jordan Harband"
+  },
+  "bugs": {
+    "url": "https://github.com/ljharb/es-to-primitive/issues"
+  },
+  "bundleDependencies": false,
+  "dependencies": {
+    "is-callable": "^1.1.1",
+    "is-date-object": "^1.0.1",
+    "is-symbol": "^1.0.1"
+  },
+  "deprecated": false,
+  "description": "ECMAScript “ToPrimitive” algorithm. Provides ES5 and ES6 versions.",
+  "devDependencies": {
+    "@ljharb/eslint-config": "^1.6.1",
+    "covert": "^1.1.0",
+    "eslint": "^1.10.3",
+    "foreach": "^2.0.5",
+    "jscs": "^2.7.0",
+    "nsp": "^2.2.0",
+    "object-is": "^1.0.1",
+    "replace": "^0.3.0",
+    "semver": "^5.1.0",
+    "tape": "^4.4.0"
+  },
+  "engines": {
+    "node": ">= 0.4"
+  },
+  "homepage": "https://github.com/ljharb/es-to-primitive#readme",
+  "keywords": [
+    "primitive",
+    "abstract",
+    "ecmascript",
+    "es5",
+    "es6",
+    "toPrimitive",
+    "coerce",
+    "type",
+    "object"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "name": "es-to-primitive",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ljharb/es-to-primitive.git"
+  },
+  "scripts": {
+    "coverage": "covert test/*.js",
+    "coverage-quiet": "covert test/*.js --quiet",
+    "eslint": "eslint test/*.js *.js",
+    "jscs": "jscs test/*.js *.js",
+    "lint": "npm run jscs && npm run eslint",
+    "security": "nsp check",
+    "test": "npm run lint && npm run tests-only && npm run security",
+    "tests-only": "node --es-staging test"
+  },
+  "testling": {
+    "files": "test",
+    "browsers": [
+      "iexplore/6.0..latest",
+      "firefox/3.0..6.0",
+      "firefox/15.0..latest",
+      "firefox/nightly",
+      "chrome/4.0..10.0",
+      "chrome/20.0..latest",
+      "chrome/canary",
+      "opera/10.0..latest",
+      "opera/next",
+      "safari/4.0..latest",
+      "ipad/6.0..latest",
+      "iphone/6.0..latest",
+      "android-browser/4.2"
+    ]
+  },
+  "version": "1.1.1"
+}

--- a/test/mock/identical-implementation/node_modules/es-to-primitive/test/es5.js
+++ b/test/mock/identical-implementation/node_modules/es-to-primitive/test/es5.js
@@ -1,0 +1,247 @@
+'use strict';
+
+const test = require('tape');
+const toPrimitive = require('../es5');
+const is = require('object-is');
+const forEach = require('foreach');
+const debug = require('util').inspect;
+
+const primitives = [
+    null,
+    undefined,
+    true,
+    false,
+    0,
+    -0,
+    42,
+    NaN,
+    Infinity,
+    -Infinity,
+    '',
+    'abc',
+];
+
+test('primitives', t => {
+    forEach(primitives, i => {
+        t.ok(
+            is(toPrimitive(i), i),
+            `toPrimitive(${debug(i)}) returns the same value`
+        );
+        t.ok(
+            is(toPrimitive(i, String), i),
+            `toPrimitive(${debug(i)}, String) returns the same value`
+        );
+        t.ok(
+            is(toPrimitive(i, Number), i),
+            `toPrimitive(${debug(i)}, Number) returns the same value`
+        );
+    });
+    t.end();
+});
+
+test('Arrays', t => {
+    const arrays = [[], ['a', 'b'], [1, 2]];
+    forEach(arrays, arr => {
+        t.ok(
+            is(toPrimitive(arr), arr.toString()),
+            `toPrimitive(${debug(arr)}) returns toString of the array`
+        );
+        t.equal(
+            toPrimitive(arr, String),
+            arr.toString(),
+            `toPrimitive(${debug(arr)}) returns toString of the array`
+        );
+        t.ok(
+            is(toPrimitive(arr, Number), arr.toString()),
+            `toPrimitive(${debug(arr)}) returns toString of the array`
+        );
+    });
+    t.end();
+});
+
+test('Dates', t => {
+    const dates = [new Date(), new Date(0), new Date(NaN)];
+    forEach(dates, date => {
+        t.equal(
+            toPrimitive(date),
+            date.toString(),
+            `toPrimitive(${debug(date)}) returns toString of the date`
+        );
+        t.equal(
+            toPrimitive(date, String),
+            date.toString(),
+            `toPrimitive(${debug(date)}) returns toString of the date`
+        );
+        t.ok(
+            is(toPrimitive(date, Number), date.valueOf()),
+            `toPrimitive(${debug(date)}) returns valueOf of the date`
+        );
+    });
+    t.end();
+});
+
+const coercibleObject = {
+    valueOf() {
+        return 3;
+    },
+    toString() {
+        return 42;
+    },
+};
+const valueOfOnlyObject = {
+    valueOf() {
+        return 4;
+    },
+    toString() {
+        return {};
+    },
+};
+const toStringOnlyObject = {
+    valueOf() {
+        return {};
+    },
+    toString() {
+        return 7;
+    },
+};
+const coercibleFnObject = {
+    valueOf() {
+        return function valueOfFn() {};
+    },
+    toString() {
+        return 42;
+    },
+};
+const uncoercibleObject = {
+    valueOf() {
+        return {};
+    },
+    toString() {
+        return {};
+    },
+};
+const uncoercibleFnObject = {
+    valueOf() {
+        return function valueOfFn() {};
+    },
+    toString() {
+        return function toStrFn() {};
+    },
+};
+
+test('Objects', t => {
+    t.equal(
+        toPrimitive(coercibleObject),
+        coercibleObject.valueOf(),
+        'coercibleObject with no hint coerces to valueOf'
+    );
+    t.equal(
+        toPrimitive(coercibleObject, String),
+        coercibleObject.toString(),
+        'coercibleObject with hint String coerces to toString'
+    );
+    t.equal(
+        toPrimitive(coercibleObject, Number),
+        coercibleObject.valueOf(),
+        'coercibleObject with hint Number coerces to valueOf'
+    );
+
+    t.equal(
+        toPrimitive(coercibleFnObject),
+        coercibleFnObject.toString(),
+        'coercibleFnObject coerces to toString'
+    );
+    t.equal(
+        toPrimitive(coercibleFnObject, String),
+        coercibleFnObject.toString(),
+        'coercibleFnObject with hint String coerces to toString'
+    );
+    t.equal(
+        toPrimitive(coercibleFnObject, Number),
+        coercibleFnObject.toString(),
+        'coercibleFnObject with hint Number coerces to toString'
+    );
+
+    t.ok(
+        is(toPrimitive({}), '[object Object]'),
+        '{} with no hint coerces to Object#toString'
+    );
+    t.equal(
+        toPrimitive({}, String),
+        '[object Object]',
+        '{} with hint String coerces to Object#toString'
+    );
+    t.ok(
+        is(toPrimitive({}, Number), '[object Object]'),
+        '{} with hint Number coerces to Object#toString'
+    );
+
+    t.equal(
+        toPrimitive(toStringOnlyObject),
+        toStringOnlyObject.toString(),
+        'toStringOnlyObject returns toString'
+    );
+    t.equal(
+        toPrimitive(toStringOnlyObject, String),
+        toStringOnlyObject.toString(),
+        'toStringOnlyObject with hint String returns toString'
+    );
+    t.equal(
+        toPrimitive(toStringOnlyObject, Number),
+        toStringOnlyObject.toString(),
+        'toStringOnlyObject with hint Number returns toString'
+    );
+
+    t.equal(
+        toPrimitive(valueOfOnlyObject),
+        valueOfOnlyObject.valueOf(),
+        'valueOfOnlyObject returns valueOf'
+    );
+    t.equal(
+        toPrimitive(valueOfOnlyObject, String),
+        valueOfOnlyObject.valueOf(),
+        'valueOfOnlyObject with hint String returns valueOf'
+    );
+    t.equal(
+        toPrimitive(valueOfOnlyObject, Number),
+        valueOfOnlyObject.valueOf(),
+        'valueOfOnlyObject with hint Number returns valueOf'
+    );
+
+    t.test('exceptions', st => {
+        st.throws(
+            toPrimitive.bind(null, uncoercibleObject),
+            TypeError,
+            'uncoercibleObject throws a TypeError'
+        );
+        st.throws(
+            toPrimitive.bind(null, uncoercibleObject, String),
+            TypeError,
+            'uncoercibleObject with hint String throws a TypeError'
+        );
+        st.throws(
+            toPrimitive.bind(null, uncoercibleObject, Number),
+            TypeError,
+            'uncoercibleObject with hint Number throws a TypeError'
+        );
+
+        st.throws(
+            toPrimitive.bind(null, uncoercibleFnObject),
+            TypeError,
+            'uncoercibleFnObject throws a TypeError'
+        );
+        st.throws(
+            toPrimitive.bind(null, uncoercibleFnObject, String),
+            TypeError,
+            'uncoercibleFnObject with hint String throws a TypeError'
+        );
+        st.throws(
+            toPrimitive.bind(null, uncoercibleFnObject, Number),
+            TypeError,
+            'uncoercibleFnObject with hint Number throws a TypeError'
+        );
+        st.end();
+    });
+
+    t.end();
+});

--- a/test/mock/identical-implementation/node_modules/es-to-primitive/test/es6.js
+++ b/test/mock/identical-implementation/node_modules/es-to-primitive/test/es6.js
@@ -1,0 +1,390 @@
+'use strict';
+
+const test = require('tape');
+const toPrimitive = require('../es6');
+const is = require('object-is');
+const forEach = require('foreach');
+const debug = require('util').inspect;
+
+const hasSymbols =
+    typeof Symbol === 'function' && typeof Symbol.iterator === 'symbol';
+const hasSymbolToPrimitive =
+    hasSymbols && typeof Symbol.toPrimitive === 'symbol';
+
+const primitives = [
+    null,
+    undefined,
+    true,
+    false,
+    0,
+    -0,
+    42,
+    NaN,
+    Infinity,
+    -Infinity,
+    '',
+    'abc',
+];
+
+test('primitives', t => {
+    forEach(primitives, i => {
+        t.ok(
+            is(toPrimitive(i), i),
+            `toPrimitive(${debug(i)}) returns the same value`
+        );
+        t.ok(
+            is(toPrimitive(i, String), i),
+            `toPrimitive(${debug(i)}, String) returns the same value`
+        );
+        t.ok(
+            is(toPrimitive(i, Number), i),
+            `toPrimitive(${debug(i)}, Number) returns the same value`
+        );
+    });
+    t.end();
+});
+
+test('Symbols', { skip: !hasSymbols }, t => {
+    const symbols = [Symbol(), Symbol.iterator, Symbol.for('foo')];
+    forEach(symbols, sym => {
+        t.equal(
+            toPrimitive(sym),
+            sym,
+            `toPrimitive(${debug(sym)}) returns the same value`
+        );
+        t.equal(
+            toPrimitive(sym, String),
+            sym,
+            `toPrimitive(${debug(sym)}, String) returns the same value`
+        );
+        t.equal(
+            toPrimitive(sym, Number),
+            sym,
+            `toPrimitive(${debug(sym)}, Number) returns the same value`
+        );
+    });
+
+    const primitiveSym = Symbol('primitiveSym');
+    const objectSym = Object(primitiveSym);
+    t.equal(
+        toPrimitive(objectSym),
+        primitiveSym,
+        `toPrimitive(${debug(objectSym)}) returns ${debug(primitiveSym)}`
+    );
+    t.equal(
+        toPrimitive(objectSym, String),
+        primitiveSym,
+        `toPrimitive(${debug(objectSym)}, String) returns ${debug(
+            primitiveSym
+        )}`
+    );
+    t.equal(
+        toPrimitive(objectSym, Number),
+        primitiveSym,
+        `toPrimitive(${debug(objectSym)}, Number) returns ${debug(
+            primitiveSym
+        )}`
+    );
+    t.end();
+});
+
+test('Arrays', t => {
+    const arrays = [[], ['a', 'b'], [1, 2]];
+    forEach(arrays, arr => {
+        t.equal(
+            toPrimitive(arr),
+            String(arr),
+            `toPrimitive(${debug(arr)}) returns the string version of the array`
+        );
+        t.equal(
+            toPrimitive(arr, String),
+            String(arr),
+            `toPrimitive(${debug(arr)}) returns the string version of the array`
+        );
+        t.equal(
+            toPrimitive(arr, Number),
+            String(arr),
+            `toPrimitive(${debug(arr)}) returns the string version of the array`
+        );
+    });
+    t.end();
+});
+
+test('Dates', t => {
+    const dates = [new Date(), new Date(0), new Date(NaN)];
+    forEach(dates, date => {
+        t.equal(
+            toPrimitive(date),
+            String(date),
+            `toPrimitive(${debug(date)}) returns the string version of the date`
+        );
+        t.equal(
+            toPrimitive(date, String),
+            String(date),
+            `toPrimitive(${debug(date)}) returns the string version of the date`
+        );
+        t.ok(
+            is(toPrimitive(date, Number), Number(date)),
+            `toPrimitive(${debug(date)}) returns the number version of the date`
+        );
+    });
+    t.end();
+});
+
+const coercibleObject = {
+    valueOf() {
+        return 3;
+    },
+    toString() {
+        return 42;
+    },
+};
+const valueOfOnlyObject = {
+    valueOf() {
+        return 4;
+    },
+    toString() {
+        return {};
+    },
+};
+const toStringOnlyObject = {
+    valueOf() {
+        return {};
+    },
+    toString() {
+        return 7;
+    },
+};
+const coercibleFnObject = {
+    valueOf() {
+        return function valueOfFn() {};
+    },
+    toString() {
+        return 42;
+    },
+};
+const uncoercibleObject = {
+    valueOf() {
+        return {};
+    },
+    toString() {
+        return {};
+    },
+};
+const uncoercibleFnObject = {
+    valueOf() {
+        return function valueOfFn() {};
+    },
+    toString() {
+        return function toStrFn() {};
+    },
+};
+
+test('Objects', t => {
+    t.equal(
+        toPrimitive(coercibleObject),
+        coercibleObject.valueOf(),
+        'coercibleObject with no hint coerces to valueOf'
+    );
+    t.equal(
+        toPrimitive(coercibleObject, Number),
+        coercibleObject.valueOf(),
+        'coercibleObject with hint Number coerces to valueOf'
+    );
+    t.equal(
+        toPrimitive(coercibleObject, String),
+        coercibleObject.toString(),
+        'coercibleObject with hint String coerces to non-stringified toString'
+    );
+
+    t.equal(
+        toPrimitive(coercibleFnObject),
+        coercibleFnObject.toString(),
+        'coercibleFnObject coerces to non-stringified toString'
+    );
+    t.equal(
+        toPrimitive(coercibleFnObject, Number),
+        coercibleFnObject.toString(),
+        'coercibleFnObject with hint Number coerces to non-stringified toString'
+    );
+    t.equal(
+        toPrimitive(coercibleFnObject, String),
+        coercibleFnObject.toString(),
+        'coercibleFnObject with hint String coerces to non-stringified toString'
+    );
+
+    t.equal(
+        toPrimitive({}),
+        '[object Object]',
+        '{} with no hint coerces to Object#toString'
+    );
+    t.equal(
+        toPrimitive({}, Number),
+        '[object Object]',
+        '{} with hint Number coerces to Object#toString'
+    );
+    t.equal(
+        toPrimitive({}, String),
+        '[object Object]',
+        '{} with hint String coerces to Object#toString'
+    );
+
+    t.equal(
+        toPrimitive(toStringOnlyObject),
+        toStringOnlyObject.toString(),
+        'toStringOnlyObject returns non-stringified toString'
+    );
+    t.equal(
+        toPrimitive(toStringOnlyObject, Number),
+        toStringOnlyObject.toString(),
+        'toStringOnlyObject with hint Number returns non-stringified toString'
+    );
+    t.equal(
+        toPrimitive(toStringOnlyObject, String),
+        toStringOnlyObject.toString(),
+        'toStringOnlyObject with hint String returns non-stringified toString'
+    );
+
+    t.equal(
+        toPrimitive(valueOfOnlyObject),
+        valueOfOnlyObject.valueOf(),
+        'valueOfOnlyObject returns valueOf'
+    );
+    t.equal(
+        toPrimitive(valueOfOnlyObject, Number),
+        valueOfOnlyObject.valueOf(),
+        'valueOfOnlyObject with hint Number returns valueOf'
+    );
+    t.equal(
+        toPrimitive(valueOfOnlyObject, String),
+        valueOfOnlyObject.valueOf(),
+        'valueOfOnlyObject with hint String returns non-stringified valueOf'
+    );
+
+    t.test('Symbol.toPrimitive', { skip: !hasSymbolToPrimitive }, st => {
+        const overriddenObject = { toString: st.fail, valueOf: st.fail };
+        overriddenObject[Symbol.toPrimitive] = function(hint) {
+            return String(hint);
+        };
+
+        st.equal(
+            toPrimitive(overriddenObject),
+            'default',
+            'object with Symbol.toPrimitive + no hint invokes that'
+        );
+        st.equal(
+            toPrimitive(overriddenObject, Number),
+            'number',
+            'object with Symbol.toPrimitive + hint Number invokes that'
+        );
+        st.equal(
+            toPrimitive(overriddenObject, String),
+            'string',
+            'object with Symbol.toPrimitive + hint String invokes that'
+        );
+
+        const nullToPrimitive = {
+            toString: coercibleObject.toString,
+            valueOf: coercibleObject.valueOf,
+        };
+        nullToPrimitive[Symbol.toPrimitive] = null;
+        st.equal(
+            toPrimitive(nullToPrimitive),
+            toPrimitive(coercibleObject),
+            'object with no hint + null Symbol.toPrimitive ignores it'
+        );
+        st.equal(
+            toPrimitive(nullToPrimitive, Number),
+            toPrimitive(coercibleObject, Number),
+            'object with hint Number + null Symbol.toPrimitive ignores it'
+        );
+        st.equal(
+            toPrimitive(nullToPrimitive, String),
+            toPrimitive(coercibleObject, String),
+            'object with hint String + null Symbol.toPrimitive ignores it'
+        );
+
+        st.test('exceptions', sst => {
+            const nonFunctionToPrimitive = {
+                toString: sst.fail,
+                valueOf: sst.fail,
+            };
+            nonFunctionToPrimitive[Symbol.toPrimitive] = {};
+            sst.throws(
+                toPrimitive.bind(null, nonFunctionToPrimitive),
+                TypeError,
+                'Symbol.toPrimitive returning a non-function throws'
+            );
+
+            const uncoercibleToPrimitive = {
+                toString: sst.fail,
+                valueOf: sst.fail,
+            };
+            uncoercibleToPrimitive[Symbol.toPrimitive] = function(hint) {
+                return {
+                    toString() {
+                        return hint;
+                    },
+                };
+            };
+            sst.throws(
+                toPrimitive.bind(null, uncoercibleToPrimitive),
+                TypeError,
+                'Symbol.toPrimitive returning an object throws'
+            );
+
+            const throwingToPrimitive = {
+                toString: sst.fail,
+                valueOf: sst.fail,
+            };
+            throwingToPrimitive[Symbol.toPrimitive] = function(hint) {
+                throw new RangeError(hint);
+            };
+            sst.throws(
+                toPrimitive.bind(null, throwingToPrimitive),
+                RangeError,
+                'Symbol.toPrimitive throwing throws'
+            );
+
+            sst.end();
+        });
+
+        st.end();
+    });
+
+    t.test('exceptions', st => {
+        st.throws(
+            toPrimitive.bind(null, uncoercibleObject),
+            TypeError,
+            'uncoercibleObject throws a TypeError'
+        );
+        st.throws(
+            toPrimitive.bind(null, uncoercibleObject, Number),
+            TypeError,
+            'uncoercibleObject with hint Number throws a TypeError'
+        );
+        st.throws(
+            toPrimitive.bind(null, uncoercibleObject, String),
+            TypeError,
+            'uncoercibleObject with hint String throws a TypeError'
+        );
+
+        st.throws(
+            toPrimitive.bind(null, uncoercibleFnObject),
+            TypeError,
+            'uncoercibleFnObject throws a TypeError'
+        );
+        st.throws(
+            toPrimitive.bind(null, uncoercibleFnObject, Number),
+            TypeError,
+            'uncoercibleFnObject with hint Number throws a TypeError'
+        );
+        st.throws(
+            toPrimitive.bind(null, uncoercibleFnObject, String),
+            TypeError,
+            'uncoercibleFnObject with hint String throws a TypeError'
+        );
+        st.end();
+    });
+    t.end();
+});

--- a/test/mock/identical-implementation/node_modules/es-to-primitive/test/index.js
+++ b/test/mock/identical-implementation/node_modules/es-to-primitive/test/index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const toPrimitive = require('../');
+const ES5 = require('../es5');
+const ES6 = require('../es6');
+
+const test = require('tape');
+
+test('default export', t => {
+    t.equal(toPrimitive, ES6, 'default export is ES6');
+    t.equal(toPrimitive.ES5, ES5, 'ES5 property has ES5 method');
+    t.equal(toPrimitive.ES6, ES6, 'ES6 property has ES6 method');
+    t.end();
+});
+
+require('./es5');
+require('./es6');

--- a/test/mock/identical-implementation/node_modules/foreach/component.json
+++ b/test/mock/identical-implementation/node_modules/foreach/component.json
@@ -1,0 +1,11 @@
+{
+    "name": "foreach",
+    "description": "foreach component + npm package",
+    "version": "2.0.5",
+    "keywords": [],
+    "dependencies": {},
+    "scripts": [
+        "index.js"
+    ],
+    "repo": "manuelstofer/foreach"
+}

--- a/test/mock/identical-implementation/node_modules/foreach/index.js
+++ b/test/mock/identical-implementation/node_modules/foreach/index.js
@@ -1,0 +1,20 @@
+const hasOwn = Object.prototype.hasOwnProperty;
+const toString = Object.prototype.toString;
+
+module.exports = function forEach(obj, fn, ctx) {
+    if (toString.call(fn) !== '[object Function]') {
+        throw new TypeError('iterator must be a function');
+    }
+    const l = obj.length;
+    if (l === +l) {
+        for (let i = 0; i < l; i++) {
+            fn.call(ctx, obj[i], i, obj);
+        }
+    } else {
+        for (const k in obj) {
+            if (hasOwn.call(obj, k)) {
+                fn.call(ctx, obj[k], k, obj);
+            }
+        }
+    }
+};

--- a/test/mock/identical-implementation/node_modules/foreach/package.json
+++ b/test/mock/identical-implementation/node_modules/foreach/package.json
@@ -1,0 +1,88 @@
+{
+  "_from": "foreach@^2.0.5",
+  "_id": "foreach@2.0.5",
+  "_inBundle": false,
+  "_integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+  "_location": "/foreach",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "range",
+    "registry": true,
+    "raw": "foreach@^2.0.5",
+    "name": "foreach",
+    "escapedName": "foreach",
+    "rawSpec": "^2.0.5",
+    "saveSpec": null,
+    "fetchSpec": "^2.0.5"
+  },
+  "_requiredBy": [
+    "/define-properties"
+  ],
+  "_resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+  "_shasum": "0bee005018aeb260d0a3af3ae658dd0136ec1b99",
+  "_spec": "foreach@^2.0.5",
+  "_where": "/Users/ricwalke/src/asset-pipe/asset-pipe-js-writer/test/mock/identical-implementation/node_modules/define-properties",
+  "author": {
+    "name": "Manuel Stofer",
+    "email": "manuel@takimata.ch"
+  },
+  "bugs": {
+    "url": "https://github.com/manuelstofer/foreach/issues"
+  },
+  "bundleDependencies": false,
+  "contributors": [
+    {
+      "name": "Manuel Stofer"
+    },
+    {
+      "name": "Jordan Harband",
+      "url": "https://github.com/ljharb"
+    }
+  ],
+  "dependencies": {},
+  "deprecated": false,
+  "description": "foreach component + npm package",
+  "devDependencies": {
+    "covert": "*",
+    "tape": "*"
+  },
+  "homepage": "https://github.com/manuelstofer/foreach#readme",
+  "keywords": [
+    "shim",
+    "Array.prototype.forEach",
+    "forEach",
+    "Array#forEach",
+    "each"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "name": "foreach",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/manuelstofer/foreach.git"
+  },
+  "scripts": {
+    "coverage": "covert test.js",
+    "coverage-quiet": "covert --quiet test.js",
+    "test": "node test.js"
+  },
+  "testling": {
+    "files": "test.js",
+    "browsers": [
+      "iexplore/6.0..latest",
+      "firefox/3.0",
+      "firefox/15.0..latest",
+      "firefox/nightly",
+      "chrome/4.0",
+      "chrome/22.0..latest",
+      "chrome/canary",
+      "opera/10.0..latest",
+      "opera/next",
+      "safari/5.0.5..latest",
+      "ipad/6.0..latest",
+      "iphone/6.0..latest",
+      "android-browser/4.2"
+    ]
+  },
+  "version": "2.0.5"
+}

--- a/test/mock/identical-implementation/node_modules/function-bind/implementation.js
+++ b/test/mock/identical-implementation/node_modules/function-bind/implementation.js
@@ -1,0 +1,54 @@
+'use strict';
+
+/* eslint no-invalid-this: 1 */
+
+const ERROR_MESSAGE = 'Function.prototype.bind called on incompatible ';
+const slice = Array.prototype.slice;
+const toStr = Object.prototype.toString;
+const funcType = '[object Function]';
+
+module.exports = function bind(that) {
+    const target = this;
+    if (typeof target !== 'function' || toStr.call(target) !== funcType) {
+        throw new TypeError(ERROR_MESSAGE + target);
+    }
+    const args = slice.call(arguments, 1);
+
+    let bound;
+    const binder = function() {
+        if (this instanceof bound) {
+            const result = target.apply(
+                this,
+                args.concat(slice.call(arguments))
+            );
+            if (Object(result) === result) {
+                return result;
+            }
+            return this;
+        } else {
+            return target.apply(that, args.concat(slice.call(arguments)));
+        }
+    };
+
+    const boundLength = Math.max(0, target.length - args.length);
+    const boundArgs = [];
+    for (let i = 0; i < boundLength; i++) {
+        boundArgs.push(`$${i}`);
+    }
+
+    bound = Function(
+        'binder',
+        `return function (${boundArgs.join(
+            ','
+        )}){ return binder.apply(this,arguments); }`
+    )(binder);
+
+    if (target.prototype) {
+        const Empty = function Empty() {};
+        Empty.prototype = target.prototype;
+        bound.prototype = new Empty();
+        Empty.prototype = null;
+    }
+
+    return bound;
+};

--- a/test/mock/identical-implementation/node_modules/function-bind/index.js
+++ b/test/mock/identical-implementation/node_modules/function-bind/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const implementation = require('./implementation');
+
+module.exports = Function.prototype.bind || implementation;

--- a/test/mock/identical-implementation/node_modules/function-bind/package.json
+++ b/test/mock/identical-implementation/node_modules/function-bind/package.json
@@ -1,0 +1,97 @@
+{
+  "_from": "function-bind@^1.1.0",
+  "_id": "function-bind@1.1.1",
+  "_inBundle": false,
+  "_integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+  "_location": "/function-bind",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "range",
+    "registry": true,
+    "raw": "function-bind@^1.1.0",
+    "name": "function-bind",
+    "escapedName": "function-bind",
+    "rawSpec": "^1.1.0",
+    "saveSpec": null,
+    "fetchSpec": "^1.1.0"
+  },
+  "_requiredBy": [
+    "/es-abstract",
+    "/has",
+    "/object.entries",
+    "/object.values"
+  ],
+  "_resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+  "_shasum": "a56899d3ea3c9bab874bb9773b7c5ede92f4895d",
+  "_spec": "function-bind@^1.1.0",
+  "_where": "/Users/ricwalke/src/asset-pipe/asset-pipe-js-writer/test/mock/identical-implementation/node_modules/object.entries",
+  "author": {
+    "name": "Raynos",
+    "email": "raynos2@gmail.com"
+  },
+  "bugs": {
+    "url": "https://github.com/Raynos/function-bind/issues",
+    "email": "raynos2@gmail.com"
+  },
+  "bundleDependencies": false,
+  "contributors": [
+    {
+      "name": "Raynos"
+    },
+    {
+      "name": "Jordan Harband",
+      "url": "https://github.com/ljharb"
+    }
+  ],
+  "dependencies": {},
+  "deprecated": false,
+  "description": "Implementation of Function.prototype.bind",
+  "devDependencies": {
+    "@ljharb/eslint-config": "^12.2.1",
+    "covert": "^1.1.0",
+    "eslint": "^4.5.0",
+    "jscs": "^3.0.7",
+    "tape": "^4.8.0"
+  },
+  "homepage": "https://github.com/Raynos/function-bind",
+  "keywords": [
+    "function",
+    "bind",
+    "shim",
+    "es5"
+  ],
+  "license": "MIT",
+  "main": "index",
+  "name": "function-bind",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/Raynos/function-bind.git"
+  },
+  "scripts": {
+    "coverage": "covert test/*.js",
+    "eslint": "eslint *.js */*.js",
+    "jscs": "jscs *.js */*.js",
+    "lint": "npm run jscs && npm run eslint",
+    "posttest": "npm run coverage -- --quiet",
+    "pretest": "npm run lint",
+    "test": "npm run tests-only",
+    "tests-only": "node test"
+  },
+  "testling": {
+    "files": "test/index.js",
+    "browsers": [
+      "ie/8..latest",
+      "firefox/16..latest",
+      "firefox/nightly",
+      "chrome/22..latest",
+      "chrome/canary",
+      "opera/12..latest",
+      "opera/next",
+      "safari/5.1..latest",
+      "ipad/6.0..latest",
+      "iphone/6.0..latest",
+      "android-browser/4.2..latest"
+    ]
+  },
+  "version": "1.1.1"
+}

--- a/test/mock/identical-implementation/node_modules/has/package.json
+++ b/test/mock/identical-implementation/node_modules/has/package.json
@@ -1,0 +1,65 @@
+{
+  "_from": "has@^1.0.1",
+  "_id": "has@1.0.1",
+  "_inBundle": false,
+  "_integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+  "_location": "/has",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "range",
+    "registry": true,
+    "raw": "has@^1.0.1",
+    "name": "has",
+    "escapedName": "has",
+    "rawSpec": "^1.0.1",
+    "saveSpec": null,
+    "fetchSpec": "^1.0.1"
+  },
+  "_requiredBy": [
+    "/es-abstract",
+    "/is-regex",
+    "/object.entries",
+    "/object.values"
+  ],
+  "_resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+  "_shasum": "8461733f538b0837c9361e39a9ab9e9704dc2f28",
+  "_spec": "has@^1.0.1",
+  "_where": "/Users/ricwalke/src/asset-pipe/asset-pipe-js-writer/test/mock/identical-implementation/node_modules/object.entries",
+  "author": {
+    "name": "Thiago de Arruda",
+    "email": "tpadilha84@gmail.com"
+  },
+  "bugs": {
+    "url": "https://github.com/tarruda/has/issues"
+  },
+  "bundleDependencies": false,
+  "dependencies": {
+    "function-bind": "^1.0.2"
+  },
+  "deprecated": false,
+  "description": "Object.prototype.hasOwnProperty.call shortcut",
+  "devDependencies": {
+    "chai": "~1.7.2",
+    "mocha": "^1.21.4"
+  },
+  "engines": {
+    "node": ">= 0.8.0"
+  },
+  "homepage": "https://github.com/tarruda/has",
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/tarruda/has/blob/master/LICENSE-MIT"
+    }
+  ],
+  "main": "./src/index",
+  "name": "has",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/tarruda/has.git"
+  },
+  "scripts": {
+    "test": "node_modules/mocha/bin/mocha"
+  },
+  "version": "1.0.1"
+}

--- a/test/mock/identical-implementation/node_modules/has/src/index.js
+++ b/test/mock/identical-implementation/node_modules/has/src/index.js
@@ -1,0 +1,3 @@
+const bind = require('function-bind');
+
+module.exports = bind.call(Function.call, Object.prototype.hasOwnProperty);

--- a/test/mock/identical-implementation/node_modules/is-callable/index.js
+++ b/test/mock/identical-implementation/node_modules/is-callable/index.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const fnToStr = Function.prototype.toString;
+
+const constructorRegex = /^\s*class /;
+const isES6ClassFn = function isES6ClassFn(value) {
+    try {
+        const fnStr = fnToStr.call(value);
+        const singleStripped = fnStr.replace(/\/\/.*\n/g, '');
+        const multiStripped = singleStripped.replace(/\/\*[.\s\S]*\*\//g, '');
+        const spaceStripped = multiStripped
+            .replace(/\n/gm, ' ')
+            .replace(/ {2}/g, ' ');
+        return constructorRegex.test(spaceStripped);
+    } catch (e) {
+        return false; // not a function
+    }
+};
+
+const tryFunctionObject = function tryFunctionObject(value) {
+    try {
+        if (isES6ClassFn(value)) {
+            return false;
+        }
+        fnToStr.call(value);
+        return true;
+    } catch (e) {
+        return false;
+    }
+};
+const toStr = Object.prototype.toString;
+const fnClass = '[object Function]';
+const genClass = '[object GeneratorFunction]';
+const hasToStringTag =
+    typeof Symbol === 'function' && typeof Symbol.toStringTag === 'symbol';
+
+module.exports = function isCallable(value) {
+    if (!value) {
+        return false;
+    }
+    if (typeof value !== 'function' && typeof value !== 'object') {
+        return false;
+    }
+    if (hasToStringTag) {
+        return tryFunctionObject(value);
+    }
+    if (isES6ClassFn(value)) {
+        return false;
+    }
+    const strClass = toStr.call(value);
+    return strClass === fnClass || strClass === genClass;
+};

--- a/test/mock/identical-implementation/node_modules/is-callable/package.json
+++ b/test/mock/identical-implementation/node_modules/is-callable/package.json
@@ -1,0 +1,114 @@
+{
+  "_from": "is-callable@^1.1.3",
+  "_id": "is-callable@1.1.3",
+  "_inBundle": false,
+  "_integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+  "_location": "/is-callable",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "range",
+    "registry": true,
+    "raw": "is-callable@^1.1.3",
+    "name": "is-callable",
+    "escapedName": "is-callable",
+    "rawSpec": "^1.1.3",
+    "saveSpec": null,
+    "fetchSpec": "^1.1.3"
+  },
+  "_requiredBy": [
+    "/es-abstract",
+    "/es-to-primitive"
+  ],
+  "_resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+  "_shasum": "86eb75392805ddc33af71c92a0eedf74ee7604b2",
+  "_spec": "is-callable@^1.1.3",
+  "_where": "/Users/ricwalke/src/asset-pipe/asset-pipe-js-writer/test/mock/identical-implementation/node_modules/es-abstract",
+  "author": {
+    "name": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "url": "http://ljharb.codes"
+  },
+  "bugs": {
+    "url": "https://github.com/ljharb/is-callable/issues"
+  },
+  "bundleDependencies": false,
+  "contributors": [
+    {
+      "name": "Jordan Harband",
+      "email": "ljharb@gmail.com",
+      "url": "http://ljharb.codes"
+    }
+  ],
+  "dependencies": {},
+  "deprecated": false,
+  "description": "Is this JS value callable? Works with Functions and GeneratorFunctions, despite ES6 @@toStringTag.",
+  "devDependencies": {
+    "@ljharb/eslint-config": "^2.1.1",
+    "covert": "^1.1.0",
+    "editorconfig-tools": "^0.1.1",
+    "eslint": "^2.2.0",
+    "foreach": "^2.0.5",
+    "jscs": "^2.10.1",
+    "make-arrow-function": "^1.1.0",
+    "make-generator-function": "^1.1.0",
+    "nsp": "^2.2.0",
+    "parallelshell": "^2.0.0",
+    "semver": "^5.1.0",
+    "tape": "^4.4.0"
+  },
+  "engines": {
+    "node": ">= 0.4"
+  },
+  "homepage": "https://github.com/ljharb/is-callable#readme",
+  "keywords": [
+    "Function",
+    "function",
+    "callable",
+    "generator",
+    "generator function",
+    "arrow",
+    "arrow function",
+    "ES6",
+    "toStringTag",
+    "@@toStringTag"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "name": "is-callable",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ljharb/is-callable.git"
+  },
+  "scripts": {
+    "coverage": "covert test.js",
+    "coverage-quiet": "covert test.js --quiet",
+    "eccheck": "editorconfig-tools check *.js **/*.js > /dev/null",
+    "eslint": "eslint *.js",
+    "jscs": "jscs *.js",
+    "lint": "npm run jscs && npm run eslint",
+    "security": "nsp check",
+    "test": "npm run lint && npm run tests-only && npm run security",
+    "test:staging": "node --es-staging test.js",
+    "test:stock": "node test.js",
+    "tests-only": "parallelshell 'npm run test:stock' 'npm run test:staging'"
+  },
+  "testling": {
+    "files": "test.js",
+    "browsers": [
+      "iexplore/6.0..latest",
+      "firefox/3.0..6.0",
+      "firefox/15.0..latest",
+      "firefox/nightly",
+      "chrome/4.0..10.0",
+      "chrome/20.0..latest",
+      "chrome/canary",
+      "opera/10.0..latest",
+      "opera/next",
+      "safari/4.0..latest",
+      "ipad/6.0..latest",
+      "iphone/6.0..latest",
+      "android-browser/4.2"
+    ]
+  },
+  "version": "1.1.3"
+}

--- a/test/mock/identical-implementation/node_modules/is-callable/test.js
+++ b/test/mock/identical-implementation/node_modules/is-callable/test.js
@@ -1,0 +1,154 @@
+'use strict';
+
+/* eslint no-magic-numbers: 1 */
+
+const test = require('tape');
+const isCallable = require('./');
+const hasSymbols = typeof Symbol === 'function' && typeof Symbol() === 'symbol';
+const genFn = require('make-generator-function');
+const arrowFn = require('make-arrow-function')();
+const forEach = require('foreach');
+
+const invokeFunction = function invokeFunction(str) {
+    let result;
+    try {
+        /* eslint-disable no-new-func */
+        const fn = Function(str);
+        /* eslint-enable no-new-func */
+        result = fn();
+    } catch (e) {
+        /**/
+    }
+    return result;
+};
+
+const classConstructor = invokeFunction('"use strict"; return class Foo {}');
+
+const commentedClass = invokeFunction(
+    '"use strict"; return class/*kkk*/\n//blah\n Bar\n//blah\n {}'
+);
+
+test('not callables', t => {
+    t.test('non-number/string primitives', st => {
+        st.notOk(isCallable(), 'undefined is not callable');
+        st.notOk(isCallable(null), 'null is not callable');
+        st.notOk(isCallable(false), 'false is not callable');
+        st.notOk(isCallable(true), 'true is not callable');
+        st.end();
+    });
+
+    t.notOk(isCallable([]), 'array is not callable');
+    t.notOk(isCallable({}), 'object is not callable');
+    t.notOk(isCallable(/a/g), 'regex literal is not callable');
+    t.notOk(isCallable(new RegExp('a', 'g')), 'regex object is not callable');
+    t.notOk(isCallable(new Date()), 'new Date() is not callable');
+
+    t.test('numbers', st => {
+        st.notOk(isCallable(42), 'number is not callable');
+        st.notOk(isCallable(Object(42)), 'number object is not callable');
+        st.notOk(isCallable(NaN), 'NaN is not callable');
+        st.notOk(isCallable(Infinity), 'Infinity is not callable');
+        st.end();
+    });
+
+    t.test('strings', st => {
+        st.notOk(isCallable('foo'), 'string primitive is not callable');
+        st.notOk(isCallable(Object('foo')), 'string object is not callable');
+        st.end();
+    });
+
+    t.test('non-function with function in its [[Prototype]] chain', st => {
+        const Foo = function Bar() {};
+        Foo.prototype = function() {};
+        st.equal(true, isCallable(Foo), 'sanity check: Foo is callable');
+        st.equal(
+            false,
+            isCallable(new Foo()),
+            'instance of Foo is not callable'
+        );
+        st.end();
+    });
+
+    t.end();
+});
+
+test('@@toStringTag', { skip: !hasSymbols || !Symbol.toStringTag }, t => {
+    const fn = function() {
+        return 3;
+    };
+    const fakeFunction = {
+        toString() {
+            return String(fn);
+        },
+        valueOf() {
+            return fn;
+        },
+    };
+    fakeFunction[Symbol.toStringTag] = 'Function';
+    t.notOk(
+        isCallable(fakeFunction),
+        'fake Function with @@toStringTag "Function" is not callable'
+    );
+    t.end();
+});
+
+const typedArrayNames = [
+    'Int8Array',
+    'Uint8Array',
+    'Uint8ClampedArray',
+    'Int16Array',
+    'Uint16Array',
+    'Int32Array',
+    'Uint32Array',
+    'Float32Array',
+    'Float64Array',
+];
+
+test('Functions', t => {
+    t.ok(isCallable(() => {}), 'function is callable');
+    t.ok(
+        isCallable(function classFake() {}),
+        'function with name containing "class" is callable'
+    );
+    t.ok(
+        isCallable(() => ' class '),
+        'function with string " class " is callable'
+    );
+    t.ok(isCallable(isCallable), 'isCallable is callable');
+    t.end();
+});
+
+test('Typed Arrays', st => {
+    forEach(typedArrayNames, typedArray => {
+        if (typeof global[typedArray] !== 'undefined') {
+            st.ok(isCallable(global[typedArray]), `${typedArray} is callable`);
+        }
+    });
+    st.end();
+});
+
+test('Generators', { skip: !genFn }, t => {
+    t.ok(isCallable(genFn), 'generator function is callable');
+    t.end();
+});
+
+test('Arrow functions', { skip: !arrowFn }, t => {
+    t.ok(isCallable(arrowFn), 'arrow function is callable');
+    t.end();
+});
+
+test(
+    '"Class" constructors',
+    { skip: !classConstructor || !commentedClass },
+    t => {
+        t.notOk(
+            isCallable(classConstructor),
+            'class constructors are not callable'
+        );
+        t.notOk(
+            isCallable(commentedClass),
+            'class constructors with comments in the signature are not callable'
+        );
+        t.end();
+    }
+);

--- a/test/mock/identical-implementation/node_modules/is-date-object/index.js
+++ b/test/mock/identical-implementation/node_modules/is-date-object/index.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const getDay = Date.prototype.getDay;
+const tryDateObject = function tryDateObject(value) {
+    try {
+        getDay.call(value);
+        return true;
+    } catch (e) {
+        return false;
+    }
+};
+
+const toStr = Object.prototype.toString;
+const dateClass = '[object Date]';
+const hasToStringTag =
+    typeof Symbol === 'function' && typeof Symbol.toStringTag === 'symbol';
+
+module.exports = function isDateObject(value) {
+    if (typeof value !== 'object' || value === null) {
+        return false;
+    }
+    return hasToStringTag
+        ? tryDateObject(value)
+        : toStr.call(value) === dateClass;
+};

--- a/test/mock/identical-implementation/node_modules/is-date-object/package.json
+++ b/test/mock/identical-implementation/node_modules/is-date-object/package.json
@@ -1,0 +1,93 @@
+{
+  "_from": "is-date-object@^1.0.1",
+  "_id": "is-date-object@1.0.1",
+  "_inBundle": false,
+  "_integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+  "_location": "/is-date-object",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "range",
+    "registry": true,
+    "raw": "is-date-object@^1.0.1",
+    "name": "is-date-object",
+    "escapedName": "is-date-object",
+    "rawSpec": "^1.0.1",
+    "saveSpec": null,
+    "fetchSpec": "^1.0.1"
+  },
+  "_requiredBy": [
+    "/es-to-primitive"
+  ],
+  "_resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+  "_shasum": "9aa20eb6aeebbff77fbd33e74ca01b33581d3a16",
+  "_spec": "is-date-object@^1.0.1",
+  "_where": "/Users/ricwalke/src/asset-pipe/asset-pipe-js-writer/test/mock/identical-implementation/node_modules/es-to-primitive",
+  "author": {
+    "name": "Jordan Harband"
+  },
+  "bugs": {
+    "url": "https://github.com/ljharb/is-date-object/issues"
+  },
+  "bundleDependencies": false,
+  "dependencies": {},
+  "deprecated": false,
+  "description": "Is this value a JS Date object? This module works cross-realm/iframe, and despite ES6 @@toStringTag.",
+  "devDependencies": {
+    "@ljharb/eslint-config": "^1.2.0",
+    "covert": "^1.1.0",
+    "eslint": "^1.5.1",
+    "foreach": "^2.0.5",
+    "indexof": "^0.0.1",
+    "is": "^3.1.0",
+    "jscs": "^2.1.1",
+    "nsp": "^1.1.0",
+    "semver": "^5.0.3",
+    "tape": "^4.2.0"
+  },
+  "engines": {
+    "node": ">= 0.4"
+  },
+  "homepage": "https://github.com/ljharb/is-date-object#readme",
+  "keywords": [
+    "Date",
+    "ES6",
+    "toStringTag",
+    "@@toStringTag",
+    "Date object"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "name": "is-date-object",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ljharb/is-date-object.git"
+  },
+  "scripts": {
+    "coverage": "covert test.js",
+    "coverage-quiet": "covert test.js --quiet",
+    "eslint": "eslint test.js *.js",
+    "jscs": "jscs test.js *.js",
+    "lint": "npm run jscs && npm run eslint",
+    "security": "nsp package",
+    "test": "npm run lint && node --harmony --es-staging test.js && npm run security"
+  },
+  "testling": {
+    "files": "test.js",
+    "browsers": [
+      "iexplore/6.0..latest",
+      "firefox/3.0..6.0",
+      "firefox/15.0..latest",
+      "firefox/nightly",
+      "chrome/4.0..10.0",
+      "chrome/20.0..latest",
+      "chrome/canary",
+      "opera/10.0..latest",
+      "opera/next",
+      "safari/4.0..latest",
+      "ipad/6.0..latest",
+      "iphone/6.0..latest",
+      "android-browser/4.2"
+    ]
+  },
+  "version": "1.0.1"
+}

--- a/test/mock/identical-implementation/node_modules/is-date-object/test.js
+++ b/test/mock/identical-implementation/node_modules/is-date-object/test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const test = require('tape');
+const isDate = require('./');
+const hasSymbols = typeof Symbol === 'function' && typeof Symbol() === 'symbol';
+
+test('not Dates', t => {
+    t.notOk(isDate(), 'undefined is not Date');
+    t.notOk(isDate(null), 'null is not Date');
+    t.notOk(isDate(false), 'false is not Date');
+    t.notOk(isDate(true), 'true is not Date');
+    t.notOk(isDate(42), 'number is not Date');
+    t.notOk(isDate('foo'), 'string is not Date');
+    t.notOk(isDate([]), 'array is not Date');
+    t.notOk(isDate({}), 'object is not Date');
+    t.notOk(isDate(() => {}), 'function is not Date');
+    t.notOk(isDate(/a/g), 'regex literal is not Date');
+    t.notOk(isDate(new RegExp('a', 'g')), 'regex object is not Date');
+    t.end();
+});
+
+test('@@toStringTag', { skip: !hasSymbols || !Symbol.toStringTag }, t => {
+    const realDate = new Date();
+    const fakeDate = {
+        toString() {
+            return String(realDate);
+        },
+        valueOf() {
+            return realDate.getTime();
+        },
+    };
+    fakeDate[Symbol.toStringTag] = 'Date';
+    t.notOk(
+        isDate(fakeDate),
+        'fake Date with @@toStringTag "Date" is not Date'
+    );
+    t.end();
+});
+
+test('Dates', t => {
+    t.ok(isDate(new Date()), 'new Date() is Date');
+    t.end();
+});

--- a/test/mock/identical-implementation/node_modules/is-regex/index.js
+++ b/test/mock/identical-implementation/node_modules/is-regex/index.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const has = require('has');
+const regexExec = RegExp.prototype.exec;
+const gOPD = Object.getOwnPropertyDescriptor;
+
+const tryRegexExecCall = function tryRegexExec(value) {
+    try {
+        var lastIndex = value.lastIndex;
+        value.lastIndex = 0;
+
+        regexExec.call(value);
+        return true;
+    } catch (e) {
+        return false;
+    } finally {
+        value.lastIndex = lastIndex;
+    }
+};
+const toStr = Object.prototype.toString;
+const regexClass = '[object RegExp]';
+const hasToStringTag =
+    typeof Symbol === 'function' && typeof Symbol.toStringTag === 'symbol';
+
+module.exports = function isRegex(value) {
+    if (!value || typeof value !== 'object') {
+        return false;
+    }
+    if (!hasToStringTag) {
+        return toStr.call(value) === regexClass;
+    }
+
+    const descriptor = gOPD(value, 'lastIndex');
+    const hasLastIndexDataProperty = descriptor && has(descriptor, 'value');
+    if (!hasLastIndexDataProperty) {
+        return false;
+    }
+
+    return tryRegexExecCall(value);
+};

--- a/test/mock/identical-implementation/node_modules/is-regex/package.json
+++ b/test/mock/identical-implementation/node_modules/is-regex/package.json
@@ -1,0 +1,100 @@
+{
+  "_from": "is-regex@^1.0.4",
+  "_id": "is-regex@1.0.4",
+  "_inBundle": false,
+  "_integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+  "_location": "/is-regex",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "range",
+    "registry": true,
+    "raw": "is-regex@^1.0.4",
+    "name": "is-regex",
+    "escapedName": "is-regex",
+    "rawSpec": "^1.0.4",
+    "saveSpec": null,
+    "fetchSpec": "^1.0.4"
+  },
+  "_requiredBy": [
+    "/es-abstract"
+  ],
+  "_resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+  "_shasum": "5517489b547091b0930e095654ced25ee97e9491",
+  "_spec": "is-regex@^1.0.4",
+  "_where": "/Users/ricwalke/src/asset-pipe/asset-pipe-js-writer/test/mock/identical-implementation/node_modules/es-abstract",
+  "author": {
+    "name": "Jordan Harband"
+  },
+  "bugs": {
+    "url": "https://github.com/ljharb/is-regex/issues"
+  },
+  "bundleDependencies": false,
+  "dependencies": {
+    "has": "^1.0.1"
+  },
+  "deprecated": false,
+  "description": "Is this value a JS regex? Works cross-realm/iframe, and despite ES6 @@toStringTag",
+  "devDependencies": {
+    "@ljharb/eslint-config": "^11.0.0",
+    "covert": "^1.1.0",
+    "editorconfig-tools": "^0.1.1",
+    "eslint": "^3.15.0",
+    "jscs": "^3.0.7",
+    "nsp": "^2.6.2",
+    "replace": "^0.3.0",
+    "semver": "^5.3.0",
+    "tape": "^4.6.3"
+  },
+  "engines": {
+    "node": ">= 0.4"
+  },
+  "homepage": "https://github.com/ljharb/is-regex",
+  "keywords": [
+    "regex",
+    "regexp",
+    "is",
+    "regular expression",
+    "regular",
+    "expression"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "name": "is-regex",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ljharb/is-regex.git"
+  },
+  "scripts": {
+    "coverage": "covert test.js",
+    "coverage-quiet": "covert test.js --quiet",
+    "eccheck": "editorconfig-tools check *.js **/*.js > /dev/null",
+    "eslint": "eslint test.js *.js",
+    "jscs": "jscs *.js",
+    "lint": "npm run jscs && npm run eslint",
+    "posttest": "npm run security",
+    "pretest": "npm run lint",
+    "security": "nsp check",
+    "test": "npm run tests-only",
+    "tests-only": "node --harmony --es-staging test.js"
+  },
+  "testling": {
+    "files": "test.js",
+    "browsers": [
+      "iexplore/6.0..latest",
+      "firefox/3.0..6.0",
+      "firefox/15.0..latest",
+      "firefox/nightly",
+      "chrome/4.0..10.0",
+      "chrome/20.0..latest",
+      "chrome/canary",
+      "opera/10.0..12.0",
+      "opera/15.0..latest",
+      "opera/next",
+      "safari/4.0..latest",
+      "ipad/6.0..latest",
+      "iphone/6.0..latest",
+      "android-browser/4.2"
+    ]
+  },
+  "version": "1.0.4"
+}

--- a/test/mock/identical-implementation/node_modules/is-symbol/index.js
+++ b/test/mock/identical-implementation/node_modules/is-symbol/index.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const toStr = Object.prototype.toString;
+const hasSymbols = typeof Symbol === 'function' && typeof Symbol() === 'symbol';
+
+if (hasSymbols) {
+    const symToStr = Symbol.prototype.toString;
+    const symStringRegex = /^Symbol\(.*\)$/;
+    const isSymbolObject = function isSymbolObject(value) {
+        if (typeof value.valueOf() !== 'symbol') {
+            return false;
+        }
+        return symStringRegex.test(symToStr.call(value));
+    };
+    module.exports = function isSymbol(value) {
+        if (typeof value === 'symbol') {
+            return true;
+        }
+        if (toStr.call(value) !== '[object Symbol]') {
+            return false;
+        }
+        try {
+            return isSymbolObject(value);
+        } catch (e) {
+            return false;
+        }
+    };
+} else {
+    module.exports = function isSymbol(value) {
+        // this environment does not support Symbols.
+        return false;
+    };
+}

--- a/test/mock/identical-implementation/node_modules/is-symbol/package.json
+++ b/test/mock/identical-implementation/node_modules/is-symbol/package.json
@@ -1,0 +1,85 @@
+{
+  "_from": "is-symbol@^1.0.1",
+  "_id": "is-symbol@1.0.1",
+  "_inBundle": false,
+  "_integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+  "_location": "/is-symbol",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "range",
+    "registry": true,
+    "raw": "is-symbol@^1.0.1",
+    "name": "is-symbol",
+    "escapedName": "is-symbol",
+    "rawSpec": "^1.0.1",
+    "saveSpec": null,
+    "fetchSpec": "^1.0.1"
+  },
+  "_requiredBy": [
+    "/es-to-primitive"
+  ],
+  "_resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+  "_shasum": "3cc59f00025194b6ab2e38dbae6689256b660572",
+  "_spec": "is-symbol@^1.0.1",
+  "_where": "/Users/ricwalke/src/asset-pipe/asset-pipe-js-writer/test/mock/identical-implementation/node_modules/es-to-primitive",
+  "author": {
+    "name": "Jordan Harband"
+  },
+  "bugs": {
+    "url": "https://github.com/ljharb/is-symbol/issues"
+  },
+  "bundleDependencies": false,
+  "dependencies": {},
+  "deprecated": false,
+  "description": "Determine if a value is an ES6 Symbol or not.",
+  "devDependencies": {
+    "covert": "1.0.0",
+    "jscs": "~1.10.0",
+    "nsp": "~1.0.0",
+    "semver": "~4.2.0",
+    "tape": "~3.4.0"
+  },
+  "engines": {
+    "node": ">= 0.4"
+  },
+  "homepage": "https://github.com/ljharb/is-symbol#readme",
+  "keywords": [
+    "symbol",
+    "es6",
+    "is",
+    "Symbol"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "name": "is-symbol",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ljharb/is-symbol.git"
+  },
+  "scripts": {
+    "coverage": "covert test/index.js",
+    "coverage:quiet": "covert test/index.js --quiet",
+    "lint": "jscs *.js */*.js",
+    "security": "nsp package",
+    "test": "npm run lint && node --es-staging --harmony test/index.js && npm run security"
+  },
+  "testling": {
+    "files": "test/index.js",
+    "browsers": [
+      "iexplore/6.0..latest",
+      "firefox/3.0..6.0",
+      "firefox/15.0..latest",
+      "firefox/nightly",
+      "chrome/4.0..10.0",
+      "chrome/20.0..latest",
+      "chrome/canary",
+      "opera/10.0..latest",
+      "opera/next",
+      "safari/4.0..latest",
+      "ipad/6.0..latest",
+      "iphone/6.0..latest",
+      "android-browser/4.2"
+    ]
+  },
+  "version": "1.0.1"
+}

--- a/test/mock/identical-implementation/node_modules/object-keys/index.js
+++ b/test/mock/identical-implementation/node_modules/object-keys/index.js
@@ -1,0 +1,153 @@
+'use strict';
+
+// modified from https://github.com/es-shims/es5-shim
+const has = Object.prototype.hasOwnProperty;
+const toStr = Object.prototype.toString;
+const slice = Array.prototype.slice;
+const isArgs = require('./isArguments');
+const isEnumerable = Object.prototype.propertyIsEnumerable;
+const hasDontEnumBug = !isEnumerable.call({ toString: null }, 'toString');
+const hasProtoEnumBug = isEnumerable.call(() => {}, 'prototype');
+const dontEnums = [
+    'toString',
+    'toLocaleString',
+    'valueOf',
+    'hasOwnProperty',
+    'isPrototypeOf',
+    'propertyIsEnumerable',
+    'constructor',
+];
+const equalsConstructorPrototype = function(o) {
+    const ctor = o.constructor;
+    return ctor && ctor.prototype === o;
+};
+const excludedKeys = {
+    $console: true,
+    $external: true,
+    $frame: true,
+    $frameElement: true,
+    $frames: true,
+    $innerHeight: true,
+    $innerWidth: true,
+    $outerHeight: true,
+    $outerWidth: true,
+    $pageXOffset: true,
+    $pageYOffset: true,
+    $parent: true,
+    $scrollLeft: true,
+    $scrollTop: true,
+    $scrollX: true,
+    $scrollY: true,
+    $self: true,
+    $webkitIndexedDB: true,
+    $webkitStorageInfo: true,
+    $window: true,
+};
+const hasAutomationEqualityBug = (function() {
+    /* global window */
+    if (typeof window === 'undefined') {
+        return false;
+    }
+    for (const k in window) {
+        try {
+            if (
+                !excludedKeys[`$${k}`] &&
+                has.call(window, k) &&
+                window[k] !== null &&
+                typeof window[k] === 'object'
+            ) {
+                try {
+                    equalsConstructorPrototype(window[k]);
+                } catch (e) {
+                    return true;
+                }
+            }
+        } catch (e) {
+            return true;
+        }
+    }
+    return false;
+})();
+const equalsConstructorPrototypeIfNotBuggy = function(o) {
+    /* global window */
+    if (typeof window === 'undefined' || !hasAutomationEqualityBug) {
+        return equalsConstructorPrototype(o);
+    }
+    try {
+        return equalsConstructorPrototype(o);
+    } catch (e) {
+        return false;
+    }
+};
+
+const keysShim = function keys(object) {
+    const isObject = object !== null && typeof object === 'object';
+    const isFunction = toStr.call(object) === '[object Function]';
+    const isArguments = isArgs(object);
+    const isString = isObject && toStr.call(object) === '[object String]';
+    const theKeys = [];
+
+    if (!isObject && !isFunction && !isArguments) {
+        throw new TypeError('Object.keys called on a non-object');
+    }
+
+    const skipProto = hasProtoEnumBug && isFunction;
+    if (isString && object.length > 0 && !has.call(object, 0)) {
+        for (let i = 0; i < object.length; ++i) {
+            theKeys.push(String(i));
+        }
+    }
+
+    if (isArguments && object.length > 0) {
+        for (let j = 0; j < object.length; ++j) {
+            theKeys.push(String(j));
+        }
+    } else {
+        for (const name in object) {
+            if (
+                !(skipProto && name === 'prototype') &&
+                has.call(object, name)
+            ) {
+                theKeys.push(String(name));
+            }
+        }
+    }
+
+    if (hasDontEnumBug) {
+        const skipConstructor = equalsConstructorPrototypeIfNotBuggy(object);
+
+        for (let k = 0; k < dontEnums.length; ++k) {
+            if (
+                !(skipConstructor && dontEnums[k] === 'constructor') &&
+                has.call(object, dontEnums[k])
+            ) {
+                theKeys.push(dontEnums[k]);
+            }
+        }
+    }
+    return theKeys;
+};
+
+keysShim.shim = function shimObjectKeys() {
+    if (Object.keys) {
+        const keysWorksWithArguments = (function() {
+            // Safari 5.0 bug
+            return (Object.keys(arguments) || '').length === 2;
+        })(1, 2);
+        if (!keysWorksWithArguments) {
+            const originalKeys = Object.keys;
+            Object.keys = function keys(object) {
+                if (isArgs(object)) {
+                    return originalKeys(slice.call(object));
+                } else {
+                    return originalKeys(object);
+                }
+            };
+        }
+    } else {
+        Object.keys = keysShim;
+    }
+    return Object.keys || keysShim;
+};
+
+module.exports = keysShim;

--- a/test/mock/identical-implementation/node_modules/object-keys/isArguments.js
+++ b/test/mock/identical-implementation/node_modules/object-keys/isArguments.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const toStr = Object.prototype.toString;
+
+module.exports = function isArguments(value) {
+    const str = toStr.call(value);
+    let isArgs = str === '[object Arguments]';
+    if (!isArgs) {
+        isArgs =
+            str !== '[object Array]' &&
+            value !== null &&
+            typeof value === 'object' &&
+            typeof value.length === 'number' &&
+            value.length >= 0 &&
+            toStr.call(value.callee) === '[object Function]';
+    }
+    return isArgs;
+};

--- a/test/mock/identical-implementation/node_modules/object-keys/package.json
+++ b/test/mock/identical-implementation/node_modules/object-keys/package.json
@@ -1,0 +1,119 @@
+{
+  "_from": "object-keys@^1.0.8",
+  "_id": "object-keys@1.0.11",
+  "_inBundle": false,
+  "_integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+  "_location": "/object-keys",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "range",
+    "registry": true,
+    "raw": "object-keys@^1.0.8",
+    "name": "object-keys",
+    "escapedName": "object-keys",
+    "rawSpec": "^1.0.8",
+    "saveSpec": null,
+    "fetchSpec": "^1.0.8"
+  },
+  "_requiredBy": [
+    "/define-properties"
+  ],
+  "_resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+  "_shasum": "c54601778ad560f1142ce0e01bcca8b56d13426d",
+  "_spec": "object-keys@^1.0.8",
+  "_where": "/Users/ricwalke/src/asset-pipe/asset-pipe-js-writer/test/mock/identical-implementation/node_modules/define-properties",
+  "author": {
+    "name": "Jordan Harband",
+    "email": "ljharb@gmail.com",
+    "url": "http://ljharb.codes"
+  },
+  "bugs": {
+    "url": "https://github.com/ljharb/object-keys/issues"
+  },
+  "bundleDependencies": false,
+  "contributors": [
+    {
+      "name": "Jordan Harband",
+      "email": "ljharb@gmail.com",
+      "url": "http://ljharb.codes"
+    },
+    {
+      "name": "Raynos",
+      "email": "raynos2@gmail.com"
+    },
+    {
+      "name": "Nathan Rajlich",
+      "email": "nathan@tootallnate.net"
+    },
+    {
+      "name": "Ivan Starkov",
+      "email": "istarkov@gmail.com"
+    },
+    {
+      "name": "Gary Katsevman",
+      "email": "git@gkatsev.com"
+    }
+  ],
+  "dependencies": {},
+  "deprecated": false,
+  "description": "An Object.keys replacement, in case Object.keys is not available. From https://github.com/es-shims/es5-shim",
+  "devDependencies": {
+    "@ljharb/eslint-config": "^6.0.0",
+    "covert": "^1.1.0",
+    "eslint": "^3.0.0",
+    "foreach": "^2.0.5",
+    "indexof": "^0.0.1",
+    "is": "^3.1.0",
+    "jscs": "^3.0.6",
+    "nsp": "^2.5.0",
+    "tape": "^4.6.0"
+  },
+  "engines": {
+    "node": ">= 0.4"
+  },
+  "homepage": "https://github.com/ljharb/object-keys#readme",
+  "keywords": [
+    "Object.keys",
+    "keys",
+    "ES5",
+    "shim"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "name": "object-keys",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ljharb/object-keys.git"
+  },
+  "scripts": {
+    "coverage": "covert test/*.js",
+    "coverage-quiet": "covert test/*.js --quiet",
+    "eslint": "eslint test/*.js *.js",
+    "jscs": "jscs test/*.js *.js",
+    "lint": "npm run --silent jscs && npm run --silent eslint",
+    "posttest": "npm run --silent security",
+    "pretest": "npm run --silent lint",
+    "security": "nsp check",
+    "test": "npm run --silent tests-only",
+    "tests-only": "node test/index.js"
+  },
+  "testling": {
+    "files": "test/index.js",
+    "browsers": [
+      "iexplore/6.0..latest",
+      "firefox/3.0..6.0",
+      "firefox/15.0..latest",
+      "firefox/nightly",
+      "chrome/4.0..10.0",
+      "chrome/20.0..latest",
+      "chrome/canary",
+      "opera/10.0..latest",
+      "opera/next",
+      "safari/4.0..latest",
+      "ipad/6.0..latest",
+      "iphone/6.0..latest",
+      "android-browser/4.2"
+    ]
+  },
+  "version": "1.0.11"
+}

--- a/test/mock/identical-implementation/node_modules/object.entries/implementation.js
+++ b/test/mock/identical-implementation/node_modules/object.entries/implementation.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const ES = require('es-abstract/es7');
+const has = require('has');
+const bind = require('function-bind');
+const isEnumerable = bind.call(
+    Function.call,
+    Object.prototype.propertyIsEnumerable
+);
+
+module.exports = function entries(O) {
+    const obj = ES.RequireObjectCoercible(O);
+    const entrys = [];
+    for (const key in obj) {
+        if (has(obj, key) && isEnumerable(obj, key)) {
+            entrys.push([key, obj[key]]);
+        }
+    }
+    return entrys;
+};

--- a/test/mock/identical-implementation/node_modules/object.entries/index.js
+++ b/test/mock/identical-implementation/node_modules/object.entries/index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const define = require('define-properties');
+
+const implementation = require('./implementation');
+const getPolyfill = require('./polyfill');
+const shim = require('./shim');
+
+const polyfill = getPolyfill();
+
+define(polyfill, {
+    getPolyfill,
+    implementation,
+    shim,
+});
+
+module.exports = polyfill;

--- a/test/mock/identical-implementation/node_modules/object.entries/package.json
+++ b/test/mock/identical-implementation/node_modules/object.entries/package.json
@@ -1,0 +1,110 @@
+{
+  "_from": "object.entries",
+  "_id": "object.entries@1.0.4",
+  "_inBundle": false,
+  "_integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+  "_location": "/object.entries",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "tag",
+    "registry": true,
+    "raw": "object.entries",
+    "name": "object.entries",
+    "escapedName": "object.entries",
+    "rawSpec": "",
+    "saveSpec": null,
+    "fetchSpec": "latest"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
+  "_shasum": "1bf9a4dd2288f5b33f3a993d257661f05d161a5f",
+  "_spec": "object.entries",
+  "_where": "/Users/ricwalke/src/asset-pipe/asset-pipe-js-writer/test/mock/identical-implementation",
+  "author": {
+    "name": "Jordan Harband"
+  },
+  "bugs": {
+    "url": "https://github.com/es-shims/Object.entries/issues"
+  },
+  "bundleDependencies": false,
+  "dependencies": {
+    "define-properties": "^1.1.2",
+    "es-abstract": "^1.6.1",
+    "function-bind": "^1.1.0",
+    "has": "^1.0.1"
+  },
+  "deprecated": false,
+  "description": "ES2017 spec-compliant Object.entries shim.",
+  "devDependencies": {
+    "@es-shims/api": "^1.2.0",
+    "@ljharb/eslint-config": "^9.0.1",
+    "array-map": "^0.0.0",
+    "covert": "^1.1.0",
+    "eslint": "^3.11.1",
+    "jscs": "^3.0.7",
+    "nsp": "^2.6.2",
+    "tape": "^4.6.3"
+  },
+  "engines": {
+    "node": ">= 0.4"
+  },
+  "homepage": "https://github.com/es-shims/Object.entries#readme",
+  "keywords": [
+    "Object.entries",
+    "Object.values",
+    "Object.keys",
+    "entries",
+    "values",
+    "ES7",
+    "ES8",
+    "ES2017",
+    "shim",
+    "object",
+    "keys",
+    "polyfill",
+    "es-shim API"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "name": "object.entries",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/es-shims/Object.entries.git"
+  },
+  "scripts": {
+    "coverage": "covert test/*.js",
+    "coverage-quiet": "covert test/*.js --quiet",
+    "eslint": "eslint test/*.js *.js",
+    "jscs": "jscs test/*.js *.js",
+    "lint": "npm run --silent jscs && npm run --silent eslint",
+    "posttest": "npm run --silent security",
+    "pretest": "npm run --silent lint",
+    "security": "nsp check",
+    "test": "npm run --silent tests-only",
+    "test:module": "node test/index.js",
+    "test:shimmed": "node test/shimmed.js",
+    "tests-only": "es-shim-api && npm run --silent test:shimmed && npm run --silent test:module"
+  },
+  "testling": {
+    "files": "test/index.js",
+    "browsers": [
+      "iexplore/9.0..latest",
+      "firefox/4.0..6.0",
+      "firefox/15.0..latest",
+      "firefox/nightly",
+      "chrome/4.0..10.0",
+      "chrome/20.0..latest",
+      "chrome/canary",
+      "opera/11.6..latest",
+      "opera/next",
+      "safari/5.0..latest",
+      "ipad/6.0..latest",
+      "iphone/6.0..latest",
+      "android-browser/4.2"
+    ]
+  },
+  "version": "1.0.4"
+}

--- a/test/mock/identical-implementation/node_modules/object.entries/polyfill.js
+++ b/test/mock/identical-implementation/node_modules/object.entries/polyfill.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const implementation = require('./implementation');
+
+module.exports = function getPolyfill() {
+    return typeof Object.entries === 'function'
+        ? Object.entries
+        : implementation;
+};

--- a/test/mock/identical-implementation/node_modules/object.entries/shim.js
+++ b/test/mock/identical-implementation/node_modules/object.entries/shim.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const getPolyfill = require('./polyfill');
+const define = require('define-properties');
+
+module.exports = function shimEntries() {
+    const polyfill = getPolyfill();
+    define(
+        Object,
+        { entries: polyfill },
+        {
+            entries: function testEntries() {
+                return Object.entries !== polyfill;
+            },
+        }
+    );
+    return polyfill;
+};

--- a/test/mock/identical-implementation/node_modules/object.values/implementation.js
+++ b/test/mock/identical-implementation/node_modules/object.values/implementation.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const ES = require('es-abstract/es7');
+const has = require('has');
+const bind = require('function-bind');
+const isEnumerable = bind.call(
+    Function.call,
+    Object.prototype.propertyIsEnumerable
+);
+
+module.exports = function values(O) {
+    const obj = ES.RequireObjectCoercible(O);
+    const vals = [];
+    for (const key in obj) {
+        if (has(obj, key) && isEnumerable(obj, key)) {
+            vals.push(obj[key]);
+        }
+    }
+    return vals;
+};

--- a/test/mock/identical-implementation/node_modules/object.values/index.js
+++ b/test/mock/identical-implementation/node_modules/object.values/index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const define = require('define-properties');
+
+const implementation = require('./implementation');
+const getPolyfill = require('./polyfill');
+const shim = require('./shim');
+
+const polyfill = getPolyfill();
+
+define(polyfill, {
+    getPolyfill,
+    implementation,
+    shim,
+});
+
+module.exports = polyfill;

--- a/test/mock/identical-implementation/node_modules/object.values/package.json
+++ b/test/mock/identical-implementation/node_modules/object.values/package.json
@@ -1,0 +1,110 @@
+{
+  "_from": "object.values",
+  "_id": "object.values@1.0.4",
+  "_inBundle": false,
+  "_integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
+  "_location": "/object.values",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "tag",
+    "registry": true,
+    "raw": "object.values",
+    "name": "object.values",
+    "escapedName": "object.values",
+    "rawSpec": "",
+    "saveSpec": null,
+    "fetchSpec": "latest"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
+  "_shasum": "e524da09b4f66ff05df457546ec72ac99f13069a",
+  "_spec": "object.values",
+  "_where": "/Users/ricwalke/src/asset-pipe/asset-pipe-js-writer/test/mock/identical-implementation",
+  "author": {
+    "name": "Jordan Harband"
+  },
+  "bugs": {
+    "url": "https://github.com/es-shims/Object.values/issues"
+  },
+  "bundleDependencies": false,
+  "dependencies": {
+    "define-properties": "^1.1.2",
+    "es-abstract": "^1.6.1",
+    "function-bind": "^1.1.0",
+    "has": "^1.0.1"
+  },
+  "deprecated": false,
+  "description": "ES2017 spec-compliant Object.values shim.",
+  "devDependencies": {
+    "@es-shims/api": "^1.2.0",
+    "@ljharb/eslint-config": "^9.0.1",
+    "array-map": "^0.0.0",
+    "covert": "^1.1.0",
+    "eslint": "^3.11.1",
+    "jscs": "^3.0.7",
+    "nsp": "^2.6.2",
+    "tape": "^4.6.3"
+  },
+  "engines": {
+    "node": ">= 0.4"
+  },
+  "homepage": "https://github.com/es-shims/Object.values#readme",
+  "keywords": [
+    "Object.values",
+    "Object.keys",
+    "Object.entries",
+    "values",
+    "ES7",
+    "ES8",
+    "ES2017",
+    "shim",
+    "object",
+    "keys",
+    "entries",
+    "polyfill",
+    "es-shim API"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "name": "object.values",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/es-shims/Object.values.git"
+  },
+  "scripts": {
+    "coverage": "covert test/*.js",
+    "coverage-quiet": "covert test/*.js --quiet",
+    "eslint": "eslint test/*.js *.js",
+    "jscs": "jscs test/*.js *.js",
+    "lint": "npm run --silent jscs && npm run --silent eslint",
+    "posttest": "npm run --silent security",
+    "pretest": "npm run --silent lint",
+    "security": "nsp check",
+    "test": "npm run --silent tests-only",
+    "test:module": "node test/index.js",
+    "test:shimmed": "node test/shimmed.js",
+    "tests-only": "es-shim-api && npm run --silent test:shimmed && npm run --silent test:module"
+  },
+  "testling": {
+    "files": "test/index.js",
+    "browsers": [
+      "iexplore/9.0..latest",
+      "firefox/4.0..6.0",
+      "firefox/15.0..latest",
+      "firefox/nightly",
+      "chrome/4.0..10.0",
+      "chrome/20.0..latest",
+      "chrome/canary",
+      "opera/11.6..latest",
+      "opera/next",
+      "safari/5.0..latest",
+      "ipad/6.0..latest",
+      "iphone/6.0..latest",
+      "android-browser/4.2"
+    ]
+  },
+  "version": "1.0.4"
+}

--- a/test/mock/identical-implementation/node_modules/object.values/polyfill.js
+++ b/test/mock/identical-implementation/node_modules/object.values/polyfill.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const implementation = require('./implementation');
+
+module.exports = function getPolyfill() {
+    return typeof Object.values === 'function' ? Object.values : implementation;
+};

--- a/test/mock/identical-implementation/node_modules/object.values/shim.js
+++ b/test/mock/identical-implementation/node_modules/object.values/shim.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const getPolyfill = require('./polyfill');
+const define = require('define-properties');
+
+module.exports = function shimValues() {
+    const polyfill = getPolyfill();
+    define(
+        Object,
+        { values: polyfill },
+        {
+            values: function testValues() {
+                return Object.values !== polyfill;
+            },
+        }
+    );
+    return polyfill;
+};

--- a/test/mock/identical-implementation/package-lock.json
+++ b/test/mock/identical-implementation/package-lock.json
@@ -1,0 +1,118 @@
+{
+  "name": "identical-implementation",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved":
+        "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
+    "es-abstract": {
+      "version": "1.10.0",
+      "resolved":
+        "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
+      "integrity":
+        "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved":
+        "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved":
+        "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity":
+        "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved":
+        "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved":
+        "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "requires": {
+        "has": "1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved":
+        "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+    },
+    "object.entries": {
+      "version": "1.0.4",
+      "resolved":
+        "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
+      "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.1"
+      }
+    },
+    "object.values": {
+      "version": "1.0.4",
+      "resolved":
+        "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
+      "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.1"
+      }
+    }
+  }
+}

--- a/test/mock/identical-implementation/package.json
+++ b/test/mock/identical-implementation/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "identical-implementation",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "object.entries": "^1.0.4",
+    "object.values": "^1.0.4"
+  }
+}

--- a/test/writer.test.js
+++ b/test/writer.test.js
@@ -51,3 +51,20 @@ test('feed is not deduped', async () => {
 
     expect(clean(result)).toMatchSnapshot();
 });
+
+test('different modules with identical source code do produce same id hash.', async () => {
+    expect.hasAssertions();
+    const writer = new Writer('./test/mock/identical-implementation');
+    const feed = await getStream(writer.bundle());
+
+    let identicalHashes = false;
+    const hashes = new Map();
+    for (const feedItem of feed) {
+        if (hashes.has(feedItem.id)) {
+            identicalHashes = true;
+            break;
+        }
+        hashes.set(feedItem.id, true);
+    }
+    expect(identicalHashes).toBe(false);
+});


### PR DESCRIPTION
## JIRA Issue
[COREWEB-196](https://jira.finn.no/browse/COREWEB-196)

## Status
**READY**

## Description
There was an obscure bug where the source code of 2 feed items was
totally identical which, when hashed, produced the same ids. Since we
can't have 2 different modules with the same id hash, we needed to add
another parameter to the hashing. I've simply taken the previous id
value (that generated by browserify) which is the path to the file
and prepended it to content to be hashed.

See source content for object.entries and object.values:
https://github.com/es-shims/Object.entries/blob/master/index.js
https://github.com/es-shims/Object.values/blob/master/index.js

## Todos
- [x] Tests

## Deploy Notes
* [ ] merge/publish
* [ ] update `@asset-pipe/client` with the new version
* [ ] update `@finn-no/podlet` with new version of the client
* [ ] update all podlets with new version of `@finn-no/podlet`
* [ ] deploy everything

## Related PRs
* None