### PR TITLE
fix: match extensions config with js-reader

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -25,7 +25,7 @@ module.exports = class Writer {
         const opts = {
             extensions: ['.js', '.es', '.es6', '.jsx', '.tsx', '.ts'],
             ...options,
-            dedupe: false
+            dedupe: false,
         };
         const browserify = new Browserify(files, opts);
         if (bundle) return browserify;

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -22,7 +22,11 @@ module.exports = class Writer {
             `Expected optional 'bundle' argument to ${name} constructor to be a boolean. Instead got '${typeof bundle}'`
         );
 
-        const opts = { ...options, dedupe: false };
+        const opts = {
+            extensions: ['.js', '.es', '.es6', '.jsx', '.tsx', '.ts'],
+            ...options,
+            dedupe: false
+        };
         const browserify = new Browserify(files, opts);
         if (bundle) return browserify;
         return browserify

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -23,7 +23,7 @@ module.exports = class Writer {
         );
 
         const opts = {
-            extensions: ['.js', '.es', '.es6', '.jsx', '.tsx', '.ts'],
+            extensions: ['.js', '.es', '.es6', '.jsx', '.tsx', '.ts', '.json'],
             ...options,
             dedupe: false,
         };


### PR DESCRIPTION
https://github.com/asset-pipe/asset-pipe-js-reader/blob/1e05eff4c09dae4cd3902144b049e79d40f8a25f/lib/reader.js#L74